### PR TITLE
Add back support for resourcet

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ dependencies:
 - hashable
 - microlens
 - mtl
+- resourcet >= 1.2
 - text
 - time
 - typed-process >= 0.2.1.0

--- a/src/RIO/Prelude.hs
+++ b/src/RIO/Prelude.hs
@@ -16,6 +16,7 @@ module RIO.Prelude
   , forMaybeM
   , stripCR
   , RIO (..)
+  , HasResource (..)
   , runRIO
   , liftRIO
   , tshow
@@ -152,6 +153,8 @@ import qualified Data.Semigroup
 import Control.Applicative (Const (..))
 import Lens.Micro.Internal ((#.))
 
+import Control.Monad.Trans.Resource.Internal (MonadResource (..), ReleaseMap, ResourceT (..))
+
 import qualified Data.Set as Set
 
 mapLeft :: (a1 -> a2) -> Either a1 b -> Either a2 b
@@ -210,6 +213,13 @@ instance MonadUnliftIO (RIO env) where
     askUnliftIO = RIO $ ReaderT $ \r ->
                   withUnliftIO $ \u ->
                   return (UnliftIO (unliftIO u . flip runReaderT r . unRIO))
+
+class HasResource env where
+  resourceL :: Lens' env (IORef ReleaseMap)
+instance HasResource (IORef ReleaseMap) where
+  resourceL = id
+instance HasResource env => MonadResource (RIO env) where
+  liftResourceT (ResourceT f) = view resourceL >>= liftIO . f
 
 tshow :: Show a => a -> Text
 tshow = T.pack . show


### PR DESCRIPTION
Possibly desired in the future, once resourcet 1.2 is ubiquitous.
Another possibility is adding a dep from resourcet onto rio (or another
package providing the RIO type, like unliftio-core).

This reverts commit 86b5ff737fbfe7971fc4ae026b3eacd08e867190.