### PR TITLE
Pervasive qualified import name documentation

### DIFF
--- a/src/RIO/ByteString/Lazy.hs
+++ b/src/RIO/ByteString/Lazy.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.ByteString.Lazy as B.Lazy
 module RIO.ByteString.Lazy
   ( module Data.ByteString.Lazy
   ) where

--- a/src/RIO/ByteString/Lazy.hs
+++ b/src/RIO/ByteString/Lazy.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | Lazy @ByteString@. Import as:
 --
 -- > import qualified RIO.ByteString.Lazy as B.Lazy
 module RIO.ByteString.Lazy

--- a/src/RIO/HashMap.hs
+++ b/src/RIO/HashMap.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.HashMap as M.Hash
 module RIO.HashMap
   ( module Data.HashMap.Strict
   ) where

--- a/src/RIO/HashMap.hs
+++ b/src/RIO/HashMap.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | Strict @Map@ with hashed keys. Import as:
 --
 -- > import qualified RIO.HashMap as M.Hash
 module RIO.HashMap

--- a/src/RIO/HashSet.hs
+++ b/src/RIO/HashSet.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.HashSet as S.Hash
 module RIO.HashSet
   ( module Data.HashSet
   ) where

--- a/src/RIO/HashSet.hs
+++ b/src/RIO/HashSet.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | @Set@ with hashed members. Import as:
 --
 -- > import qualified RIO.HashSet as S.Hash
 module RIO.HashSet

--- a/src/RIO/List.hs
+++ b/src/RIO/List.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.List as L
 module RIO.List
   ( module Data.List
   ) where

--- a/src/RIO/List.hs
+++ b/src/RIO/List.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | @List@. Import as:
 --
 -- > import qualified RIO.List as L
 module RIO.List

--- a/src/RIO/Map.hs
+++ b/src/RIO/Map.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | Strict @Map@. Import as:
 --
 -- > import qualified RIO.Map as M
 module RIO.Map

--- a/src/RIO/Map.hs
+++ b/src/RIO/Map.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.Map as M
 module RIO.Map
   ( module Data.Map.Strict
   ) where

--- a/src/RIO/Set.hs
+++ b/src/RIO/Set.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.Set as S
 module RIO.Set
   ( module Data.Set
   ) where

--- a/src/RIO/Set.hs
+++ b/src/RIO/Set.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | @Set@. Import as:
 --
 -- > import qualified RIO.Set as S
 module RIO.Set

--- a/src/RIO/Text.hs
+++ b/src/RIO/Text.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.Text as T
 module RIO.Text
   ( module Data.Text
   , Data.Text.Encoding.encodeUtf8

--- a/src/RIO/Text.hs
+++ b/src/RIO/Text.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | Strict @Text@. Import as:
 --
 -- > import qualified RIO.Text as T
 module RIO.Text

--- a/src/RIO/Text/Lazy.hs
+++ b/src/RIO/Text/Lazy.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.Text.Lazy as T.Lazy
 module RIO.Text.Lazy
   ( module Data.Text.Lazy
   ) where

--- a/src/RIO/Text/Lazy.hs
+++ b/src/RIO/Text/Lazy.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | Lazy @Text@. Import as:
 --
 -- > import qualified RIO.Text.Lazy as T.Lazy
 module RIO.Text.Lazy

--- a/src/RIO/Vector.hs
+++ b/src/RIO/Vector.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | Generic @Vector@ interface. Import as:
 --
 -- > import qualified RIO.Vector as V
 module RIO.Vector

--- a/src/RIO/Vector.hs
+++ b/src/RIO/Vector.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.Vector as V
 module RIO.Vector
   ( module Data.Vector.Generic
   ) where

--- a/src/RIO/Vector/Boxed.hs
+++ b/src/RIO/Vector/Boxed.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | Boxed @Vector@. Import as:
 --
 -- > import qualified RIO.Vector.Boxed as V.Boxed
 module RIO.Vector.Boxed

--- a/src/RIO/Vector/Boxed.hs
+++ b/src/RIO/Vector/Boxed.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.Vector.Boxed as V.Boxed
 module RIO.Vector.Boxed
   ( module Data.Vector
   ) where

--- a/src/RIO/Vector/Storable.hs
+++ b/src/RIO/Vector/Storable.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | Storable @Vector@. Import as:
 --
 -- > import qualified RIO.Vector.Storable as V.Storable
 module RIO.Vector.Storable

--- a/src/RIO/Vector/Storable.hs
+++ b/src/RIO/Vector/Storable.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.Vector.Storable as V.Storable
 module RIO.Vector.Storable
   ( module Data.Vector.Storable
   ) where

--- a/src/RIO/Vector/Unboxed.hs
+++ b/src/RIO/Vector/Unboxed.hs
@@ -1,3 +1,6 @@
+-- | Strict @ByteString@. Import as:
+--
+-- > import qualified RIO.Vector.Unboxed as V.Unboxed
 module RIO.Vector.Unboxed
   ( module Data.Vector.Unboxed
   ) where

--- a/src/RIO/Vector/Unboxed.hs
+++ b/src/RIO/Vector/Unboxed.hs
@@ -1,4 +1,4 @@
--- | Strict @ByteString@. Import as:
+-- | Unboxed @Vector@. Import as:
 --
 -- > import qualified RIO.Vector.Unboxed as V.Unboxed
 module RIO.Vector.Unboxed


### PR DESCRIPTION
Addressing #35.

For now, I went with a sort of middle ground with regards to current discussion in #12: the first layer of modules (`RIO.*`) have single-letter abbreviations, but their children are unabbreviated, e.g.:
```
import qualified RIO.Vector.Unboxed as V.Unboxed
```

The exception to this is `RIO.HashMap` and `RIO.HashSet`, which are `M.Hash` and `S.Hash` respectively, reflecting a vague hunch that it wouldn't hurt to move them in the hierarchy accordingly.