### PR TITLE
Add a symbolic link to README.md so that it shows up on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+rio/README.md


### PR DESCRIPTION
Currently, the README does not show up on https://github.com/commercialhaskell/rio .  This adds a symlink to the README.  This way it can still be directly included in the rio package.  This will degrade decently on filesystems that do not support symbolic links, it will just be a text file with the path to the readme you should look at.