### PR TITLE
Add more exports from UnliftIO.Concurrent

### DIFF
--- a/rio/src/RIO/Prelude/Reexports.hs
+++ b/rio/src/RIO/Prelude/Reexports.hs
@@ -2,6 +2,12 @@
 module RIO.Prelude.Reexports
   ( module UnliftIO
   -- List imports from UnliftIO?
+  , UnliftIO.Concurrent.ThreadId
+  , UnliftIO.Concurrent.myThreadId
+  , UnliftIO.Concurrent.isCurrentThreadBound
+  , UnliftIO.Concurrent.yield
+  , UnliftIO.Concurrent.threadWaitRead
+  , UnliftIO.Concurrent.threadWaitWrite
   , UnliftIO.Concurrent.threadDelay
   , Control.Applicative.Alternative
   , Control.Applicative.Applicative (..)

--- a/rio/src/RIO/Prelude/Reexports.hs
+++ b/rio/src/RIO/Prelude/Reexports.hs
@@ -5,10 +5,10 @@ module RIO.Prelude.Reexports
   , UnliftIO.Concurrent.ThreadId
   , UnliftIO.Concurrent.myThreadId
   , UnliftIO.Concurrent.isCurrentThreadBound
-  , UnliftIO.Concurrent.yield
   , UnliftIO.Concurrent.threadWaitRead
   , UnliftIO.Concurrent.threadWaitWrite
   , UnliftIO.Concurrent.threadDelay
+  , yieldThread
   , Control.Applicative.Alternative
   , Control.Applicative.Applicative (..)
   , Control.Applicative.liftA
@@ -305,3 +305,7 @@ import qualified GHC.Stack
 import qualified Prelude
 import qualified System.Exit
 import qualified Text.Read
+
+yieldThread :: MonadIO m => m ()
+yieldThread = UnliftIO.Concurrent.yield
+{-# INLINE yieldThread #-}


### PR DESCRIPTION
I think it is useful to have some more exports from `UnliftIO.Concurrent`. 

Another option would be to re-export `UnliftIO.Concurrent` as `RIO.Concurrent`, let me know your thoughts