### PR TITLE
Use textual I/O to handle line endings

### DIFF
--- a/rio/src/RIO/Prelude/IO.hs
+++ b/rio/src/RIO/Prelude/IO.hs
@@ -2,7 +2,6 @@ module RIO.Prelude.IO
   ( withLazyFile
   , readFileBinary
   , writeFileBinary
-  , ReadFileUtf8Exception (..)
   , readFileUtf8
   , writeFileUtf8
   , hPutBuilder
@@ -12,6 +11,8 @@ import RIO.Prelude.Reexports
 import qualified Data.ByteString.Builder  as BB
 import qualified Data.ByteString          as B
 import qualified Data.ByteString.Lazy     as BL
+import qualified Data.Text.IO             as T
+import           System.IO                (hSetEncoding, utf8)
 
 -- | Lazily get the contents of a file. Unlike 'BL.readFile', this
 -- ensures that if an exception is thrown, the file handle is closed
@@ -19,13 +20,13 @@ import qualified Data.ByteString.Lazy     as BL
 withLazyFile :: MonadUnliftIO m => FilePath -> (BL.ByteString -> m a) -> m a
 withLazyFile fp inner = withBinaryFile fp ReadMode $ inner <=< liftIO . BL.hGetContents
 
-data ReadFileUtf8Exception = ReadFileUtf8Exception !FilePath !UnicodeException
-  deriving (Show, Typeable)
-instance Exception ReadFileUtf8Exception
-
 -- | Write a file in UTF8 encoding
+--
+-- This function will use OS-specific line ending handling.
 writeFileUtf8 :: MonadIO m => FilePath -> Text -> m ()
-writeFileUtf8 fp = writeFileBinary fp . encodeUtf8
+writeFileUtf8 fp text = liftIO $ withFile fp WriteMode $ \h -> do
+  hSetEncoding h utf8
+  T.hPutStr h text
 
 hPutBuilder :: MonadIO m => Handle -> Builder -> m ()
 hPutBuilder h = liftIO . BB.hPutBuilder h
@@ -41,9 +42,9 @@ writeFileBinary fp = liftIO . B.writeFile fp
 
 -- | Read a file in UTF8 encoding, throwing an exception on invalid character
 -- encoding.
+--
+-- This function will use OS-specific line ending handling.
 readFileUtf8 :: MonadIO m => FilePath -> m Text
-readFileUtf8 fp = do
-  bs <- readFileBinary fp
-  case decodeUtf8' bs of
-    Left e     -> throwIO $ ReadFileUtf8Exception fp e
-    Right text -> return text
+readFileUtf8 fp = liftIO $ withFile fp ReadMode $ \h -> do
+  hSetEncoding h utf8
+  T.hGetContents h

--- a/rio/test/RIO/Prelude/IOSpec.hs
+++ b/rio/test/RIO/Prelude/IOSpec.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ViewPatterns #-}
+module RIO.Prelude.IOSpec (spec) where
+
+import RIO
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import qualified RIO.ByteString as B
+import qualified RIO.Text as T
+
+spec :: Spec
+spec = do
+  prop "binary file read/write" $ \(B.pack -> bs1) ->
+    withSystemTempFile "binary-read-write" $ \fp h -> do
+      hClose h
+      writeFileBinary fp bs1
+      bs2 <- readFileBinary fp
+      bs2 `shouldBe` bs1
+  prop "text file read/write" $ \(T.pack -> text1) ->
+    withSystemTempFile "binary-read-write" $ \fp h -> do
+      hClose h
+      writeFileUtf8 fp text1
+      text2 <- readFileUtf8 fp
+      text2 `shouldBe` text1

--- a/rio/test/RIO/Prelude/IOSpec.hs
+++ b/rio/test/RIO/Prelude/IOSpec.hs
@@ -17,7 +17,8 @@ spec = do
       writeFileBinary fp bs1
       bs2 <- readFileBinary fp
       bs2 `shouldBe` bs1
-  prop "text file read/write" $ \(T.pack -> text1) ->
+  -- filter our \r for Windows
+  prop "text file read/write" $ \(T.pack . filter (/= '\r') -> text1) ->
     withSystemTempFile "binary-read-write" $ \fp h -> do
       hClose h
       writeFileUtf8 fp text1


### PR DESCRIPTION
This allows the handle API to automatically deal with LF vs CRLF line
endings correctly. Pointed out to me _somewhere_ by @sol, I don't
remember where I saw it.