### PR TITLE
Hide RIO.Prelude.* modules

### DIFF
--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -45,6 +45,18 @@ when:
 
 library:
   source-dirs: src/
+  other-modules:
+    - RIO.Prelude.Display
+    - RIO.Prelude.Extra
+    - RIO.Prelude.IO
+    - RIO.Prelude.Lens
+    - RIO.Prelude.Logger
+    - RIO.Prelude.Reexports
+    - RIO.Prelude.Renames
+    - RIO.Prelude.RIO
+    - RIO.Prelude.Text
+    - RIO.Prelude.Trace
+    - RIO.Prelude.URef
 
 tests:
   spec:


### PR DESCRIPTION
Many of these modules seem a bit out of place, or otherwise only make sense in
the context of being re-exported in Rio. Particularly, the following only make
sense in that context: Extra, IO, Reexports, Renames, Text.

As such, I think for the stable release it makes sense to just hide all of them.
In later releases, additional modules / exports can be added to allow importing
of some of these things individually. This is described in #71