### PR TITLE
Remove stripCR function

### DIFF
--- a/rio/src/RIO/List.hs
+++ b/rio/src/RIO/List.hs
@@ -135,6 +135,7 @@ module RIO.List
 
   -- ** Functions on strings
   , Data.List.lines
+  , linesCR
   , Data.List.words
   , Data.List.unlines
   , Data.List.unwords
@@ -225,3 +226,12 @@ dropSuffix :: Eq a
            -> [a]
            -> [a]
 dropSuffix suffix t = fromMaybe t (stripSuffix suffix t)
+
+-- | 'linesCR' breaks a 'String' up into a list of `String`s at newline
+-- 'Char's. It is very similar to 'lines', but it also removes any
+-- trailing @'\r'@ 'Char's. The resulting 'String' values do not contain
+-- newlines or trailing @'\r'@ characters.
+--
+-- @since 0.1.0.0
+linesCR :: String -> [String]
+linesCR = map (dropSuffix "\r") . lines

--- a/rio/src/RIO/Prelude/Text.hs
+++ b/rio/src/RIO/Prelude/Text.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module RIO.Prelude.Text
-  ( stripCR
-  , decodeUtf8Lenient
+  ( decodeUtf8Lenient
   , tshow
   ) where
 
@@ -9,10 +8,6 @@ import qualified Data.Text                as T
 import Data.Text.Encoding (decodeUtf8With)
 import RIO.Prelude.Reexports
 import Data.Text.Encoding.Error (lenientDecode)
-
--- | Strip trailing carriage return from Text
-stripCR :: Text -> Text
-stripCR t = fromMaybe t (T.stripSuffix "\r" t)
 
 tshow :: Show a => a -> Text
 tshow = T.pack . show

--- a/rio/src/RIO/Text.hs
+++ b/rio/src/RIO/Text.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | Strict @Text@. Import as:
 --
@@ -162,3 +163,12 @@ dropSuffix :: Text -- ^ suffix
            -> Text
            -> Text
 dropSuffix suffix t = fromMaybe t (stripSuffix suffix t)
+
+-- | 'linesCR' breaks a 'Text' up into a list of `Text`s at newline
+-- 'Char's. It is very similar to 'Data.Text.lines', but it also removes
+-- any trailing @'\r'@ characters. The resulting 'Text' values do not
+-- contain newlines or trailing @'\r'@ characters.
+--
+-- @since 0.1.0.0
+linesCR :: Text -> [Text]
+linesCR = map (dropSuffix "\r") . Data.Text.lines


### PR DESCRIPTION
The main place this is useful is after use of some 'lines' function that splits
only on \n.  I think for these cases it makes more sense to have new 'lines'
functions which handle both \r\n and \n.