### PR TITLE
Remove some Data.Monoid wrappers

### DIFF
--- a/rio/src/RIO/Prelude/Reexports.hs
+++ b/rio/src/RIO/Prelude/Reexports.hs
@@ -149,15 +149,7 @@ module RIO.Prelude.Reexports
   , Data.Maybe.mapMaybe
   , Data.Maybe.maybe
   , Data.Maybe.maybeToList
-  , Data.Monoid.All (..)
-  , Data.Monoid.Any (..)
-  , Data.Monoid.Endo (..)
-  , Data.Monoid.First (..)
-  , Data.Monoid.Last (..)
-  , Data.Monoid.Alt (..)
   , Data.Monoid.Monoid (..)
-  , Data.Monoid.Product (..)
-  , Data.Monoid.Sum (..)
   , (Data.Monoid.<>)
   , Data.Ord.Ord(..)
   , Data.Ord.Ordering(..)


### PR DESCRIPTION
Reasoning:

* Kept 'First' / 'Last' because they are useful in many practical circumstances.
  Particularly when used with fields of a datatype + Monoid deriving.

* 'Alt' is a very general name, and off the top of my head I didn't know what it
  does.

* 'Product' / 'Sum' are pretty clear, but they are also rather popular type
  constructor names, if you search them in hoogle.  A lot of collisions and not
  used a whole ton.

* 'All' / 'Any' are also pretty clear, but similarly a fairly popular type name.

* Kept 'Endo' because I like it, though tbh I don't use it much.