### PR TITLE
Use ansi-terminal package, over raw ANSI codes

### DIFF
--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -13,6 +13,7 @@ extra-source-files:
 
 dependencies:
 - base >= 4.9 && < 10
+- ansi-terminal
 - bytestring
 - containers
 - deepseq

--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -64,6 +64,9 @@ import qualified Data.ByteString as B
 import           System.IO                  (localeEncoding)
 import           GHC.Foreign                (peekCString, withCString)
 import Data.Semigroup (Semigroup (..))
+import System.Console.ANSI (Color (Black, Blue, Green, Magenta, Red, Yellow),
+         ColorIntensity (Dull, Vivid), ConsoleLayer (Foreground),
+         SGR (Reset, SetColor), setSGRCode)
 
 -- | The log level of a message.
 --
@@ -458,13 +461,13 @@ simpleLogFunc lo cs _src level msg =
         ansi reset <>
         "\n"
   where
-   reset = "\ESC[0m"
-   setBlack = "\ESC[90m"
-   setGreen = "\ESC[32m"
-   setBlue = "\ESC[34m"
-   setYellow = "\ESC[33m"
-   setRed = "\ESC[31m"
-   setMagenta = "\ESC[35m"
+   reset = fromString $ setSGRCode [Reset]
+   setBlack = fromString $ setSGRCode [SetColor Foreground Vivid Black]
+   setGreen = fromString $ setSGRCode [SetColor Foreground Dull Green]
+   setBlue = fromString $ setSGRCode [SetColor Foreground Dull Blue]
+   setYellow = fromString $ setSGRCode [SetColor Foreground Dull Yellow]
+   setRed = fromString $ setSGRCode [SetColor Foreground Dull Red]
+   setMagenta = fromString $ setSGRCode [SetColor Foreground Dull Magenta]
 
    ansi :: Utf8Builder -> Utf8Builder
    ansi xs | logUseColor lo = xs

--- a/rio/src/RIO/Process.hs
+++ b/rio/src/RIO/Process.hs
@@ -132,6 +132,8 @@ import           System.Exit (exitWith)
 import qualified System.FilePath as FP
 import qualified System.Process.Typed as P
 import           System.Process.Typed hiding (withProcess, withProcess_, proc)
+import System.Console.ANSI (Color (Green), ColorIntensity (Vivid), ConsoleLayer
+         (Foreground), SGR (Reset, SetColor), setSGRCode)
 
 #ifndef WINDOWS
 import           System.Directory (setCurrentDirectory)
@@ -382,11 +384,14 @@ withProcessTimeLog mdir name args proc' = do
   useColor <- view logFuncUseColorL
   logDebug
       ("Process finished in " <>
-      (if useColor then "\ESC[92m" else "") <> -- green
+      (if useColor then setGreen else "") <>
       timeSpecMilliSecondText diff <>
-      (if useColor then "\ESC[0m" else "") <> -- reset
+      (if useColor then reset else "") <>
        ": " <> display cmdText)
   return x
+ where
+  setGreen = fromString $ setSGRCode [SetColor Foreground Vivid Green]
+  reset = fromString $ setSGRCode [Reset]
 
 timeSpecMilliSecondText :: Double -> Utf8Builder
 timeSpecMilliSecondText d = display (round (d * 1000) :: Int) <> "ms"


### PR DESCRIPTION
The advantage of the `ansi-terminal` package's `setSGRCode` function over the use of 'raw' ANSI codes is that, on Windows 10, the former will enable ANSI-capable ConHost terminal handles and, on legacy Windows, the former will emulate ANSI capabability on ConHost terminals (EDIT: actually, for the pure codes, the 'emulation' is to replace them with empty strings).

At the moment, `stack` v 1.7.1 outputs raw ANSI codes on Windows 10 because it is using RIO and neither `stack` nor RIO are enabling ANSI on ANSI-capable ConHost terminals. See https://github.com/commercialhaskell/stack/issues/3992.