### PR TITLE
Add support for monad-logger typeclassess for RIO

### DIFF
--- a/rio-orphans/ChangeLog.md
+++ b/rio-orphans/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio-orphans
 
+## 0.1.1.0
+
+* Add an instance for `MonadLogger` typeclass, from the `monad-logger` library
+
 ## 0.1.0.0
 
 * Initial release

--- a/rio-orphans/package.yaml
+++ b/rio-orphans/package.yaml
@@ -1,5 +1,5 @@
 name:        rio-orphans
-version:     0.1.0.0
+version:     0.1.1.0
 synopsis:    Orphan instances for the RIO type in the rio package
 description: See README and Haddocks at <https://www.stackage.org/package/rio-orphans>
 license:     MIT

--- a/rio-orphans/package.yaml
+++ b/rio-orphans/package.yaml
@@ -18,6 +18,8 @@ dependencies:
 - resourcet
 - rio
 - monad-control
+- monad-logger
+- fast-logger
 - transformers-base
 
 library:

--- a/rio-orphans/src/RIO/Orphans.hs
+++ b/rio-orphans/src/RIO/Orphans.hs
@@ -39,11 +39,11 @@ instance MonadBaseControl IO (RIO env) where
   liftBaseWith = withRunInIO
   restoreM = return
 
--- | @since 0.1.3.0
+-- | @since 0.1.1.0
 instance Display LogStr where
   display = displayBytesUtf8 . fromLogStr
 
--- | @since 0.1.3.0
+-- | @since 0.1.1.0
 instance HasLogFunc env => MonadLogger (RIO env) where
   monadLoggerLog loc source level msg =
       logGeneric source rioLogLevel (display $ LegacyLogger.toLogStr msg)


### PR DESCRIPTION
With this PR, we are going to be able to support libraries like persistent, which require `monad-logger` typeclass instances