### PR TITLE
Allow alloc of LogFunc outside a with block

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## 0.1.3.0
 
+* Add `newLogFunc` function to create `LogFunc` records outside of a callback scope
 * Allow dynamic reloading of `logMinLevel` and `logVerboseFormat` for the `LogOptions` record
 
 ## 0.1.2.0

--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -8,8 +8,8 @@ module RIO.Prelude.Logger
   , logError
   , logOther
     -- * Running with logging
-  , newLogFunc
   , withLogFunc
+  , newLogFunc
   , LogFunc
   , HasLogFunc (..)
   , logOptionsHandle

--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -8,6 +8,7 @@ module RIO.Prelude.Logger
   , logError
   , logOther
     -- * Running with logging
+  , newLogFunc
   , withLogFunc
   , LogFunc
   , HasLogFunc (..)
@@ -333,6 +334,34 @@ getCanUseUnicode = do
             return (str == str')
     test `catchIO` \_ -> return False
 
+
+-- | Given a 'LogOptions' value, returns both a new 'LogFunc' and a sub-routine that
+-- disposes it.
+--
+-- Intended for use if you want to deal with the teardown of 'LogFunc' yourself,
+-- otherwise prefer the 'withLogFunc' function instead.
+--
+--  @since  0.1.3.0
+newLogFunc :: (MonadIO n, MonadIO m) => LogOptions -> n (LogFunc, m ())
+newLogFunc options =
+  if logTerminal options then do
+    var <- newMVar mempty
+    return (LogFunc
+             { unLogFunc = stickyImpl var options (simpleLogFunc options)
+             , lfOptions = Just options
+             }
+           , do state <- takeMVar var
+                unless (B.null state) (liftIO $ logSend options "\n")
+           )
+  else
+    return (LogFunc
+            { unLogFunc = \cs src level str ->
+                simpleLogFunc options cs src (noSticky level) str
+            , lfOptions = Just options
+            }
+           , return ()
+           )
+
 -- | Given a 'LogOptions' value, run the given function with the
 -- specified 'LogFunc'. A common way to use this function is:
 --
@@ -353,23 +382,10 @@ getCanUseUnicode = do
 -- @since 0.0.0.0
 withLogFunc :: MonadUnliftIO m => LogOptions -> (LogFunc -> m a) -> m a
 withLogFunc options inner = withRunInIO $ \run -> do
-  if logTerminal options
-    then bracket
-            (newMVar mempty)
-            (\var -> do
-                state <- takeMVar var
-                unless (B.null state) (logSend options "\n"))
-            (\var -> run $ inner $ LogFunc
-                { unLogFunc = stickyImpl var options (simpleLogFunc options)
-                , lfOptions = Just options
-                }
-            )
-    else
-      run $ inner $ LogFunc
-        { unLogFunc = \cs src level str ->
-             simpleLogFunc options cs src (noSticky level) str
-        , lfOptions = Just options
-        }
+  bracket (newLogFunc options)
+          snd
+          (run . inner . fst)
+
 
 -- | Replace Unicode characters with non-Unicode equivalents
 replaceUnicode :: Char -> Char


### PR DESCRIPTION
This pull request adds the function `newLogFunc` to the `RIO.Prelude.Logger` module, this function returns a tuple with a `LogFunc` and a teardown sub-routine. This function is useful when using a mechanism other than `bracket` (e.g. [`componentm`](https://github.com/roman/Haskell-componentm/tree/master/componentm)) to deal with resource management.