### PR TITLE
Add support for ThreadId information on log messages

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -3,6 +3,11 @@
 ## 0.1.3.0
 
 * Add `newLogFunc` function to create `LogFunc` records outside of a callback scope
+* Add `ThreadId` parameter to the `LogFunc` function
+* Add `logGenericFromThread` to be able to register a log entry `CallStack` from a
+  different thread
+* Add `getLogMinLevel` to gather what is the log min level from `LogOptions`
+* Add `setLogUseThread` to add thread id to log lines
 * Allow dynamic reloading of `logMinLevel` and `logVerboseFormat` for the `LogOptions` record
 
 ## 0.1.2.0


### PR DESCRIPTION
These PR contains several changes to help on logging in multi-threaded environments:

1.  ~When running on applications with multiple threads, I would like to gather what thread did emit a log message.~ We don't require changes in the library to support this, we can pre-append or append the information to the log message itself.

2. When running on a multi-threaded application, is common to have a dedicated thread to emit logs, this PR contains changes that allows transmitting `CallStack` ~and `ThreadId`~ information to emulate a log being called from the original thread (rather than displaying information about the dedicated thread that does this).

3. When having a dedicated thread for logging, I want to know what is the `logMinLevel` of the `LogOptions` so that we don't send messages from source threads when the log level ignores them.
