### PR TITLE
Reexport Data.Functor.Const.Const, Data.Functor.Identity.Identity

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio
 
+## 0.1.4.0
+
+* Add `Const` and `Identity`
+
 ## 0.1.3.0
 
 * Add `newLogFunc` function to create `LogFunc` records outside of a callback scope

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -1,5 +1,5 @@
 name: rio
-version: 0.1.3.0
+version: 0.1.4.0
 synopsis: A standard library for Haskell
 description: See README and Haddocks at <https://www.stackage.org/package/rio>
 license: MIT

--- a/rio/src/RIO/Prelude/Reexports.hs
+++ b/rio/src/RIO/Prelude/Reexports.hs
@@ -112,6 +112,8 @@ module RIO.Prelude.Reexports
   , Data.Functor.void
   , (Data.Functor.$>)
   , (Data.Functor.<$>)
+  , Data.Functor.Const.Const(..)
+  , Data.Functor.Identity.Identity(..)
   , Data.Hashable.Hashable
   , Data.HashMap.Strict.HashMap
   , Data.HashSet.HashSet
@@ -273,6 +275,8 @@ import qualified Data.Eq
 import qualified Data.Foldable
 import qualified Data.Function
 import qualified Data.Functor
+import qualified Data.Functor.Const
+import qualified Data.Functor.Identity
 import qualified Data.Hashable
 import qualified Data.HashMap.Strict
 import qualified Data.HashSet


### PR DESCRIPTION
These are useful, simple, ubiquitous, and heavily referenced in the existing reexport docs... and we're already reexporting `Void` so I don't think they're going to shift any threshold of newbie confusion!