### PR TITLE
Reexport Control.Monad.Reader.Reader, runReader

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -3,6 +3,7 @@
 ## 0.1.4.0
 
 * Add `Const` and `Identity`
+* Add `Reader` and `runReader`
 
 ## 0.1.3.0
 

--- a/rio/src/RIO/Prelude/Reexports.hs
+++ b/rio/src/RIO/Prelude/Reexports.hs
@@ -49,6 +49,7 @@ module RIO.Prelude.Reexports
   , Control.Monad.Catch.MonadThrow(..)
   , Control.Monad.Reader.MonadReader
   , Control.Monad.Reader.MonadTrans(..)
+  , Control.Monad.Reader.Reader
   , Control.Monad.Reader.ReaderT(..)
   , Control.Monad.Reader.ask
   , Control.Monad.Reader.asks

--- a/rio/src/RIO/Prelude/Reexports.hs
+++ b/rio/src/RIO/Prelude/Reexports.hs
@@ -54,6 +54,7 @@ module RIO.Prelude.Reexports
   , Control.Monad.Reader.ask
   , Control.Monad.Reader.asks
   , Control.Monad.Reader.local
+  , Control.Monad.Reader.runReader
   , Data.Bool.Bool(..)
   , Data.Bool.bool
   , Data.Bool.not


### PR DESCRIPTION
Not strictly necessary if the reexport of Identity is adopted, but saves a bit of boilerplate.