### PR TITLE
Reexport class GHC.Records.HasField +methods

### DIFF
--- a/rio/src/RIO/Prelude/Reexports.hs
+++ b/rio/src/RIO/Prelude/Reexports.hs
@@ -179,6 +179,7 @@ module RIO.Prelude.Reexports
   , Data.Word.byteSwap64
   , Foreign.Storable.Storable
   , GHC.Generics.Generic
+  , GHC.Records.HasField(..)
   , GHC.Stack.HasCallStack
   , Prelude.Bounded (..)
   , Prelude.Double
@@ -291,6 +292,7 @@ import qualified Data.Void
 import qualified Data.Word
 import qualified Foreign.Storable
 import qualified GHC.Generics
+import qualified GHC.Records
 import qualified GHC.Stack
 import qualified Prelude
 import qualified System.Exit


### PR DESCRIPTION
Just a suggestion. This seems like the cleanest fully-standard way of disambiguating `DuplicateRecordFields`. Does have a few name conflicts on Stackage. Not sure what the floor on RIO's GHC version support is, if it's pre-8.0 this is a non-starter.