### PR TITLE
Reexport `Data.Text.replace` and `Data.Text.Lazy.replace`

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio
 
+## Unreleased
+
+* Expose `Data.Text.replace` and `Data.Text.Lazy.replace`
+
 ## 0.1.4.0
 
 * Add `Const` and `Identity`

--- a/rio/src/RIO/Text.hs
+++ b/rio/src/RIO/Text.hs
@@ -33,6 +33,7 @@ module RIO.Text
     , Data.Text.intersperse
     , Data.Text.transpose
     , Data.Text.reverse
+    , Data.Text.replace
 
     -- ** Case conversion
     , Data.Text.toCaseFold

--- a/rio/src/RIO/Text/Lazy.hs
+++ b/rio/src/RIO/Text/Lazy.hs
@@ -36,6 +36,7 @@ module RIO.Text.Lazy
     , Data.Text.Lazy.intersperse
     , Data.Text.Lazy.transpose
     , Data.Text.Lazy.reverse
+    , Data.Text.Lazy.replace
 
     -- ** Case conversion
     , Data.Text.Lazy.toCaseFold


### PR DESCRIPTION
I needed that function today and saw that it is not (yet) exposed.  So I went ahead and did it :)