### PR TITLE
Export Prelude.fromEnum from RIO, export fromJust, read and toEnum form RIO.Partial

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -4,6 +4,7 @@
 
 * Re-export `Numeric.Natural.Natural` [#119](https://github.com/commercialhaskell/rio/issues/119)
 * Re-export `Data.Functor.<&>` from GHC 8.4+, falling back local definition for `base < 4.11` [#117](https://github.com/commercialhaskell/rio/issues/117)
+* Re-export `fromEnum` from RIO, export `toEnum`, `read` and `fromJust` from RIO.Partial
 
 ## 0.1.4.0
 

--- a/rio/src/RIO/Partial.hs
+++ b/rio/src/RIO/Partial.hs
@@ -1,0 +1,10 @@
+-- | Partial functions.
+--
+module RIO.Partial
+  ( Data.Maybe.fromJust
+  , Prelude.read
+  , Prelude.toEnum
+  ) where
+
+import qualified Data.Maybe
+import qualified Prelude

--- a/rio/src/RIO/Prelude/Reexports.hs
+++ b/rio/src/RIO/Prelude/Reexports.hs
@@ -211,6 +211,7 @@ module RIO.Prelude.Reexports
   , Prelude.curry
   , Prelude.error
   , Prelude.even
+  , Prelude.fromEnum
   , Prelude.fromIntegral
   , Prelude.fst
   , Prelude.gcd


### PR DESCRIPTION
Hi, I noticed these are missing when I tried to use them.