### PR TITLE
Improve documentation of logOptionsHandle

### DIFF
--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -292,11 +292,19 @@ logOptionsMemory = do
 -- to perform verbose logging or not. Individiual settings can be
 -- overridden using appropriate @set@ functions.
 --
+-- When Verbose Flag is @True@, the following happens:
+--
+--     * @setLogVerboseFormat@ is called with @True@
+--     * @setLogUseColor@ is called with @True@
+--     * @setLogUseLoc@ is called with @True@
+--     * @setLogUseTime@ is called with @True@
+--     * @setLogMinLevel@ is called with 'Debug' log level
+--
 -- @since 0.0.0.0
 logOptionsHandle
   :: MonadIO m
   => Handle
-  -> Bool -- ^ verbose?
+  -> Bool -- ^ Verbose Flag
   -> m LogOptions
 logOptionsHandle handle' verbose = liftIO $ do
   terminal <- hIsTerminalDevice handle'


### PR DESCRIPTION
The improved documentation explains what are all the side-effects from using a `True` value in the Debug flag