### PR TITLE
logUseColor now defaults to False on Windows, even when verbose

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio
 
+## Unreleased
+
+* Changed `logUseColor` to default to `False` on Windows, even when verbose and on the terminal
+
 ## 0.1.5.0
 
 * Re-export `Numeric.Natural.Natural` [#119](https://github.com/commercialhaskell/rio/issues/119)

--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 module RIO.Prelude.Logger
@@ -68,7 +69,6 @@ import qualified Data.ByteString as B
 import           System.IO                  (localeEncoding)
 import           GHC.Foreign                (peekCString, withCString)
 import Data.Semigroup (Semigroup (..))
-import System.Info (os)
 
 -- | The log level of a message.
 --
@@ -316,7 +316,11 @@ logOptionsHandle handle' verbose = liftIO $ do
     , logVerboseFormat = return verbose
     , logTerminal = terminal
     , logUseTime = verbose
-    , logUseColor = verbose && terminal && os /= "mingw32"
+#if WINDOWS
+    , logUseColor = False
+#else
+    , logUseColor = verbose && terminal
+#endif
     , logUseLoc = verbose
     , logSend = \builder ->
         if useUtf8 && unicode

--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -68,6 +68,7 @@ import qualified Data.ByteString as B
 import           System.IO                  (localeEncoding)
 import           GHC.Foreign                (peekCString, withCString)
 import Data.Semigroup (Semigroup (..))
+import System.Info (os)
 
 -- | The log level of a message.
 --
@@ -295,7 +296,7 @@ logOptionsMemory = do
 -- When Verbose Flag is @True@, the following happens:
 --
 --     * @setLogVerboseFormat@ is called with @True@
---     * @setLogUseColor@ is called with @True@
+--     * @setLogUseColor@ is called with @True@ (except on Windows)
 --     * @setLogUseLoc@ is called with @True@
 --     * @setLogUseTime@ is called with @True@
 --     * @setLogMinLevel@ is called with 'Debug' log level
@@ -315,7 +316,7 @@ logOptionsHandle handle' verbose = liftIO $ do
     , logVerboseFormat = return verbose
     , logTerminal = terminal
     , logUseTime = verbose
-    , logUseColor = verbose && terminal
+    , logUseColor = verbose && terminal && os /= "mingw32"
     , logUseLoc = verbose
     , logSend = \builder ->
         if useUtf8 && unicode


### PR DESCRIPTION
Fixes #131 

Simple change in `logOptionsHandle`. Updated the haddock comment. Updated the change log.