### PR TITLE
Fix backslash to be appeared in haddock

### DIFF
--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -383,7 +383,7 @@ newLogFunc options =
 -- let isVerbose = False -- get from the command line instead
 -- logOptions' <- logOptionsHandle stderr isVerbose
 -- let logOptions = setLogUseTime True logOptions'
--- withLogFunc logOptions $ \lf -> do
+-- withLogFunc logOptions $ \\lf -> do
 --   let app = App -- application specific environment
 --         { appLogFunc = lf
 --         , appOtherStuff = ...


### PR DESCRIPTION
In the [example code](http://hackage.haskell.org/package/rio-0.1.5.0/docs/RIO.html#v:withLogFunc) for `withLogFunc` on haddock, backslash before `lf ->` is not properly rendered.
This PR just fixes it.