### PR TITLE
Remove unnecessary `Ord` constraint from min/max functions

### DIFF
--- a/rio/src/RIO/List.hs
+++ b/rio/src/RIO/List.hs
@@ -274,9 +274,9 @@ minimumMaybe :: (Ord a, Foldable t) => t a -> Maybe a
 minimumMaybe = safeListCall Data.List.minimum
 
 -- | @since 0.1.3.0
-maximumByMaybe :: (Ord a, Foldable t) => (a -> a -> Ordering) -> t a -> Maybe a
+maximumByMaybe :: (Foldable t) => (a -> a -> Ordering) -> t a -> Maybe a
 maximumByMaybe f = safeListCall (Data.List.maximumBy f)
 
 -- | @since 0.1.3.0
-minimumByMaybe :: (Ord a, Foldable t) => (a -> a -> Ordering) -> t a -> Maybe a
+minimumByMaybe :: (Foldable t) => (a -> a -> Ordering) -> t a -> Maybe a
 minimumByMaybe f = safeListCall (Data.List.minimumBy f)

--- a/rio/test/RIO/ListSpec.hs
+++ b/rio/test/RIO/ListSpec.hs
@@ -5,6 +5,12 @@ import Test.Hspec
 import RIO
 import qualified RIO.List as List
 
+data TestType = TestType { testTypeContents :: Int }
+  deriving (Eq, Show)
+
+testTypeList :: [TestType]
+testTypeList = [TestType { testTypeContents = 1 }, TestType { testTypeContents = 0 }]
+
 spec :: Spec
 spec = do
   describe "dropPrefix" $ do
@@ -13,3 +19,9 @@ spec = do
   describe "dropSuffix" $ do
     it "present" $ List.dropSuffix "bar" "foobar" `shouldBe` "foo"
     it "absent" $ List.dropSuffix "foo" "foobar" `shouldBe` "foobar"
+  describe "maximumByMaybe" $ do
+    it "should support elements that do not have an Ord instance" $
+      List.maximumByMaybe (compare `on` testTypeContents) testTypeList `shouldBe` (Just TestType { testTypeContents = 1})
+  describe "minimumByMaybe" $ do
+    it "should support elements that do not have an Ord instance" $
+      List.minimumByMaybe (compare `on` testTypeContents) testTypeList `shouldBe` (Just TestType { testTypeContents = 0})


### PR DESCRIPTION
Resolves #140 