### PR TITLE
Re-export `Control.Monad.State.modify`, `Control.Monad.State.modify'`…

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio
 
+## 0.1.8.0
+
+* Re-export `Control.Monad.State.modify`, `Control.Monad.State.modify'` and `Control.Monad.State.gets` in `RIO.State`
+
 ## 0.1.7.0
 
 * Addition of `textDisplay` to `Display` class.

--- a/rio/src/RIO/State.hs
+++ b/rio/src/RIO/State.hs
@@ -4,6 +4,9 @@
 module RIO.State
   (
     Control.Monad.State.MonadState (..)
+  , Control.Monad.State.gets
+  , Control.Monad.State.modify
+  , Control.Monad.State.modify'
   ) where
 
 import qualified Control.Monad.State


### PR DESCRIPTION
… and `Control.Monad.State.gets` in `RIO.State`