### PR TITLE
Re-export the `Control.Monad.State.State`, `Control.Monad.State.State…

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for rio
 
+## 0.1.9.0
+
+* Re-export the `Control.Monad.State.State` and `Control.Monad.State.StateT` types and related computation functions in `RIO.State`.
+* Re-export the `Control.Monad.Writer.Writer` and `Control.Monad.Writer.WriterT` types and related computation functions in `RIO.Writer`.
+
 ## 0.1.8.0
 
 * Re-export `Control.Monad.State.modify`, `Control.Monad.State.modify'` and `Control.Monad.State.gets` in `RIO.State`

--- a/rio/src/RIO/State.hs
+++ b/rio/src/RIO/State.hs
@@ -7,6 +7,18 @@ module RIO.State
   , Control.Monad.State.gets
   , Control.Monad.State.modify
   , Control.Monad.State.modify'
+  , Control.Monad.State.State
+  , Control.Monad.State.runState
+  , Control.Monad.State.evalState
+  , Control.Monad.State.execState
+  , Control.Monad.State.mapState
+  , Control.Monad.State.withState
+  , Control.Monad.State.StateT
+  , Control.Monad.State.runStateT
+  , Control.Monad.State.evalStateT
+  , Control.Monad.State.execStateT
+  , Control.Monad.State.mapStateT
+  , Control.Monad.State.withStateT
   ) where
 
 import qualified Control.Monad.State

--- a/rio/src/RIO/Writer.hs
+++ b/rio/src/RIO/Writer.hs
@@ -4,6 +4,16 @@
 module RIO.Writer
   (
     Control.Monad.Writer.MonadWriter (..)
+  , Control.Monad.Writer.listens
+  , Control.Monad.Writer.censor
+  , Control.Monad.Writer.Writer
+  , Control.Monad.Writer.runWriter
+  , Control.Monad.Writer.execWriter
+  , Control.Monad.Writer.mapWriter
+  , Control.Monad.Writer.WriterT
+  , Control.Monad.Writer.runWriterT
+  , Control.Monad.Writer.execWriterT
+  , Control.Monad.Writer.mapWriterT
   ) where
 
 import qualified Control.Monad.Writer


### PR DESCRIPTION
…T`, `Control,Monad.Writer.Writer` and `Control.Monad.Writer.WriterT` types and related computation functions.