### PR TITLE
Re-export `pred`, `succ` in `RIO.Partial`.

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -4,6 +4,7 @@
 
 * Re-export the `Control.Monad.State.State` and `Control.Monad.State.StateT` types and related computation functions in `RIO.State`.
 * Re-export the `Control.Monad.Writer.Writer` and `Control.Monad.Writer.WriterT` types and related computation functions in `RIO.Writer`.
+* Re-export `pred`, `succ` in `RIO.Partial`.
 
 ## 0.1.8.0
 

--- a/rio/src/RIO/Partial.hs
+++ b/rio/src/RIO/Partial.hs
@@ -4,6 +4,8 @@ module RIO.Partial
   ( Data.Maybe.fromJust
   , Prelude.read
   , Prelude.toEnum
+  , Prelude.pred
+  , Prelude.succ
   ) where
 
 import qualified Data.Maybe


### PR DESCRIPTION
I think we just overlooked these with #115, they have the same sort of bounds-related partiality as `toEnum` which was included there.