### PR TITLE
Move incorrectly classified Map conversion functions: `toAscList`, `toDescList`

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -6,6 +6,7 @@
 * Re-export the `Control.Monad.Writer.Writer` and `Control.Monad.Writer.WriterT` types and related computation functions in `RIO.Writer`.
 * Re-export `pred`, `succ` in `RIO.Partial`.
 * Add `Semigroup` and `Monoid` instances for `RIO`
+* Re-export `Data.Map.Strict.toAscList` and `Data.Map.Strict.toDescList` from `RIO.Map`.
 
 ## 0.1.8.0
 

--- a/rio/src/RIO/Map.hs
+++ b/rio/src/RIO/Map.hs
@@ -113,6 +113,12 @@ module RIO.Map
   , Data.Map.Strict.fromListWith
   , Data.Map.Strict.fromListWithKey
 
+  -- ** Ordered lists
+  , Data.Map.Strict.toAscList
+#if MIN_VERSION_containers(0,5,8)
+  , Data.Map.Strict.toDescList
+#endif
+
   -- * Filter
   , Data.Map.Strict.filter
   , Data.Map.Strict.filterWithKey

--- a/rio/src/RIO/Map/Unchecked.hs
+++ b/rio/src/RIO/Map/Unchecked.hs
@@ -12,13 +12,13 @@ module RIO.Map.Unchecked
 
   -- * Conversion
   -- ** Ordered lists
-  , Data.Map.Strict.toAscList
+  , Data.Map.Strict.toAscList -- FIXME: remove in the next major version (0.2.0.0)
   , Data.Map.Strict.fromAscList
   , Data.Map.Strict.fromAscListWith
   , Data.Map.Strict.fromAscListWithKey
   , Data.Map.Strict.fromDistinctAscList
 #if MIN_VERSION_containers(0,5,8)
-  , Data.Map.Strict.toDescList
+  , Data.Map.Strict.toDescList -- FIXME: remove in the next major version (0.2.0.0)
   , Data.Map.Strict.fromDescList
   , Data.Map.Strict.fromDescListWith
   , Data.Map.Strict.fromDescListWithKey


### PR DESCRIPTION
I don't think there is anything wrong/unchecked with:
* `Data.Map.Strict.toAscList`
* `Data.Map.Strict.toDescList`

They do not have any preconditions, other than the `Map` itself be valid. In fact `RIO.Set` exports corresponding functions.

I did not remove them from `RIO.Map.Unchecked`, otherwise it would be a breaking change, so it should be done at the next major release instead.
