### PR TITLE
add lifted versions of `System.Exit.exitFailure` and `exitSuccess`

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## 0.1.9.0
 
+* Add `Prelude.Exit` to export lifted versions of the exit functions from `System.Exit`.
 * Re-export the `Control.Monad.State.State` and `Control.Monad.State.StateT` types and related computation functions in `RIO.State`.
 * Re-export the `Control.Monad.Writer.Writer` and `Control.Monad.Writer.WriterT` types and related computation functions in `RIO.Writer`.
 * Re-export `pred`, `succ` in `RIO.Partial`.

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -47,6 +47,7 @@ library:
   source-dirs: src/
   other-modules:
     - RIO.Prelude.Display
+    - RIO.Prelude.Exit
     - RIO.Prelude.Extra
     - RIO.Prelude.IO
     - RIO.Prelude.Lens

--- a/rio/src/RIO.hs
+++ b/rio/src/RIO.hs
@@ -1,5 +1,6 @@
 module RIO
   ( module RIO.Prelude.Display
+  , module RIO.Prelude.Exit
   , module RIO.Prelude.Extra
   , module RIO.Prelude.IO
   , module RIO.Prelude.Lens
@@ -15,6 +16,7 @@ module RIO
   ) where
 
 import RIO.Prelude.Display
+import RIO.Prelude.Exit
 import RIO.Prelude.Extra
 import RIO.Prelude.IO
 import RIO.Prelude.Lens

--- a/rio/src/RIO/Prelude/Exit.hs
+++ b/rio/src/RIO/Prelude/Exit.hs
@@ -1,0 +1,31 @@
+module RIO.Prelude.Exit
+  ( exitFailure
+  , exitSuccess
+  , exitWith
+  , System.Exit.ExitCode(..)
+  ) where
+
+import           Control.Monad.IO.Class
+import qualified System.Exit ( ExitCode (..)
+                             , exitFailure
+                             , exitSuccess
+                             , exitWith
+                             )
+
+-- | Lifted version of "System.Exit.exitFailure".
+--
+-- @since 0.1.9.0.
+exitFailure :: MonadIO m => m a
+exitFailure = liftIO System.Exit.exitFailure
+
+-- | Lifted version of "System.Exit.exitSuccess".
+--
+-- @since 0.1.9.0.
+exitSuccess :: MonadIO m => m a
+exitSuccess = liftIO System.Exit.exitSuccess
+
+-- | Lifted version of "System.Exit.exitWith".
+--
+-- @since 0.1.9.0.
+exitWith :: MonadIO m => System.Exit.ExitCode -> m a
+exitWith code = liftIO $ System.Exit.exitWith code

--- a/rio/src/RIO/Prelude/Reexports.hs
+++ b/rio/src/RIO/Prelude/Reexports.hs
@@ -229,7 +229,6 @@ module RIO.Prelude.Reexports
   , (Prelude.$!)
   , (Prelude.^)
   , (Prelude.^^)
-  , System.Exit.ExitCode(..)
   , Text.Read.Read
   , Text.Read.readMaybe
     -- * Primitive


### PR DESCRIPTION
into the Rio `Prelude`, and re-exported from there.