### PR TITLE
Remove accidental reexport of `Control.Applicative.empty`  

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -3,6 +3,7 @@
 ## 0.1.9.1
 
 * Remove accidental reexport of `Control.Applicative.empty` introduced in the previous release.
+* Functions from `Data.Data.Data` class are brought to the re-export list as well.
 
 ## 0.1.9.0
 
@@ -19,7 +20,6 @@
 * Re-export `zipWith` and `runST` from `RIO.Prelude`
 * Re-export `Exception`, `MonadFail`, `Typeable` and `ST` from `RIO.Prelude.Types`
 * Switch to `MonadFail.fail` from `Monad.fail` and re-exported it from `RIO.Prelude`
-* Functions from `Data.Data.Data` class are no longer exported.
 
 
 ## 0.1.8.0

--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio
 
+## 0.1.9.1
+
+* Remove accidental reexport of `Control.Applicative.empty` introduced in the previous release.
+
 ## 0.1.9.0
 
 * Add `Prelude.Exit` to export lifted versions of the exit functions from `System.Exit`.
@@ -15,6 +19,7 @@
 * Re-export `zipWith` and `runST` from `RIO.Prelude`
 * Re-export `Exception`, `MonadFail`, `Typeable` and `ST` from `RIO.Prelude.Types`
 * Switch to `MonadFail.fail` from `Monad.fail` and re-exported it from `RIO.Prelude`
+* Functions from `Data.Data.Data` class are no longer exported.
 
 
 ## 0.1.8.0

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -1,5 +1,5 @@
 name: rio
-version: 0.1.9.0
+version: 0.1.9.1
 synopsis: A standard library for Haskell
 description: See README and Haddocks at <https://www.stackage.org/package/rio>
 license: MIT

--- a/rio/src/RIO/Prelude.hs
+++ b/rio/src/RIO/Prelude.hs
@@ -257,7 +257,6 @@ module RIO.Prelude
 
     -- * @Alternative@
     -- | Re-exported from "Control.Applicative":
-  , Control.Applicative.empty
   , (Control.Applicative.<|>)
   , Control.Applicative.some
   , Control.Applicative.many

--- a/rio/src/RIO/Prelude/Types.hs
+++ b/rio/src/RIO/Prelude/Types.hs
@@ -170,7 +170,7 @@ module RIO.Prelude.Types
   , Data.Typeable.Typeable
     -- **** @Data@
     -- | Re-exported from "Data.Data":
-  , Data.Data.Data
+  , Data.Data.Data(..)
     -- **** @Generic@
     -- | Re-exported from "GHC.Generics":
   , GHC.Generics.Generic


### PR DESCRIPTION
* Remove reexport of `empty`, which was introduced in `rio-0.1.9.0`
* Bumps up version
* Updates changelog together with a missed change for the previous version