### PR TITLE
Custom `Monoid` instance for `Utf8Builder`

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -3,6 +3,7 @@
 ## 0.1.10.0
 
 * Relax a bunch of `RIO.File` functions from `MonadUnliftIO` to `MonadIO`
+* Custom `Monoid` instance for `Utf8Builder` that matches semantics of the derived one, but doesn't break list fusion
 
 ## 0.1.9.2
 

--- a/rio/src/RIO/Prelude/Display.hs
+++ b/rio/src/RIO/Prelude/Display.hs
@@ -14,7 +14,7 @@ import           Data.ByteString          (ByteString)
 import qualified Data.ByteString.Lazy     as BL
 import qualified Data.ByteString.Builder  as BB
 import           Data.ByteString.Builder  (Builder)
-import           Data.Semigroup           (Semigroup)
+import           Data.Semigroup           (Semigroup(..))
 import           Data.Text                (Text)
 import qualified Data.Text.Lazy           as TL
 import qualified Data.Text.Lazy.Encoding  as TL
@@ -30,7 +30,17 @@ import           System.Process.Typed     (ProcessConfig, setEnvInherit)
 --
 -- @since 0.1.0.0
 newtype Utf8Builder = Utf8Builder { getUtf8Builder :: Builder }
-  deriving (Semigroup, Monoid)
+  deriving (Semigroup)
+
+-- Custom instance is created instead of deriving, otherwise list fusion breaks
+-- for `mconcat`.
+instance Monoid Utf8Builder where
+  mempty = Utf8Builder mempty
+  {-# INLINE mempty #-}
+  mappend = (Data.Semigroup.<>)
+  {-# INLINE mappend #-}
+  mconcat = foldr mappend mempty
+  {-# INLINE mconcat #-}
 
 -- | @since 0.1.0.0
 instance IsString Utf8Builder where


### PR DESCRIPTION
Because of derived instance with `GeneralizedNewtypeDeriving`, `mconcat` breaks list fusion and causes extra allocations when used with `Utf8Builder`. Here is a way to reproduce: 
```haskell
  runSimpleApp $ do
    logInfo $ foldr (<>) mempty $ fuseThis ["foo", "bar", "-", "<>"]
    logInfo $ foldr mappend mempty $ fuseThis ["foo", "bar", "-", "mappend"]
    logInfo $ mconcat $ fuseThis ["foo", "bar", "-", "mconcat"]
```
`fuseThis` comes from [`Data.List.Fusion.Probe`](http://hackage.haskell.org/package/list-fusion-probe-0.1.0.8/docs/Data-List-Fusion-Probe.html)

Code above results in:
```
foobar-<>
foobar-mappend
fuse-builder-exe: fuseThis: List did not fuse
CallStack (from HasCallStack):
  error, called at ./Data/List/Fusion/Probe.hs:52:16
```
But with the fix in this PR:
```
foobar-<>
foobar-mappend
foobar-mconcat
```