### PR TITLE
Re-export Data.Ord.Down from RIO.Prelude

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -4,6 +4,7 @@
 
 * Relax a bunch of `RIO.File` functions from `MonadUnliftIO` to `MonadIO`
 * Custom `Monoid` instance for `Utf8Builder` that matches semantics of the derived one, but doesn't break list fusion
+* Re-export `Data.Ord.Down` from `RIO.Prelude`
 
 ## 0.1.9.2
 

--- a/rio/src/RIO/Prelude.hs
+++ b/rio/src/RIO/Prelude.hs
@@ -58,6 +58,7 @@ module RIO.Prelude
   , Data.Ord.min
   , Data.Ord.compare
   , Data.Ord.comparing
+  , Data.Ord.Down(..)
 
     -- * @Enum@
     -- | Re-exported from "Prelude":
@@ -442,4 +443,3 @@ import qualified Data.Text.Encoding.Error (lenientDecode)
 
 import qualified Control.Monad.Primitive (primitive)
 import qualified Control.Monad.ST
-


### PR DESCRIPTION
Addresses #169 

The only reservation I have here is that for some reason there's no record for deconstructing a `Down` (e.g. `getDown`, `unDown`). But there also doesn't seem to be any competing implementation which does provide that.