### PR TITLE
Export Data.List.NonEmpty.NonEmpty from RIO.Prelude.Types

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -7,6 +7,7 @@
 * Re-export `Data.Ord.Down` from `RIO.Prelude`
 * Addition of `RIO.NonEmpty` module
 * Addition of `RIO.NonEmpty.Partial` module
+* Export `NonEmpty` type from RIO.Prelude.Types
 
 ## 0.1.9.2
 

--- a/rio/src/RIO/Prelude/Types.hs
+++ b/rio/src/RIO/Prelude/Types.hs
@@ -171,6 +171,9 @@ module RIO.Prelude.Types
     -- **** @Data@
     -- | Re-exported from "Data.Data":
   , Data.Data.Data(..)
+    -- **** @NonEmpty@
+    -- | Re-exported from Data.List.NonEmpty
+  , Data.List.NonEmpty.NonEmpty
     -- **** @Generic@
     -- | Re-exported from "GHC.Generics":
   , GHC.Generics.Generic
@@ -325,6 +328,7 @@ import qualified Data.Int
 import qualified Data.IntMap.Strict
 import qualified Data.IntSet
 import qualified Data.List
+import qualified Data.List.NonEmpty
 import qualified Data.Map.Strict
 import qualified Data.Maybe
 import qualified Data.Ord


### PR DESCRIPTION
I've chosen not to export the `(:|)` constructor here due to conflicts in `generic-random` and `opaleye`. Generally the smart de/constructor functions in `RIO.NonEmpty` are better anyway.