### PR TITLE
Reworking `NonEmpty`

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -3,12 +3,13 @@
 ## 0.1.10.0
 
 * Relax a bunch of `RIO.File` functions from `MonadUnliftIO` to `MonadIO`
-* Custom `Monoid` instance for `Utf8Builder` that matches semantics of the derived one, but doesn't break list fusion
+* Custom `Monoid` instance for `Utf8Builder` that matches semantics of the
+  derived one, but doesn't break list fusion
 * Qualified import recommendations for `*.Partial`, `*.Unchecked`, `*.Unsafe`
 * Re-export `Data.Ord.Down` from `RIO.Prelude`
 * Addition of `RIO.NonEmpty` module
 * Addition of `RIO.NonEmpty.Partial` module
-* Export `NonEmpty` type from RIO.Prelude.Types
+* Export `NonEmpty` type and its constructor `(:|)` from RIO.Prelude.Types
 * Fix handling of non-ASCII characters in `logSticky`
 
 ## 0.1.9.2

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -66,6 +66,8 @@ library:
     - RIO.Map
     - RIO.Map.Partial
     - RIO.Map.Unchecked
+    - RIO.NonEmpty
+    - RIO.NonEmpty.Partial
     - RIO.Partial
     - RIO.Prelude
     - RIO.Prelude.Simple

--- a/rio/src/RIO/NonEmpty.hs
+++ b/rio/src/RIO/NonEmpty.hs
@@ -64,7 +64,7 @@ module RIO.NonEmpty
   -- * Sublist predicates
   , Data.List.NonEmpty.isPrefixOf
 
-  -- * "Set" operations
+  -- * Set-like operations
   , Data.List.NonEmpty.nub
   , Data.List.NonEmpty.nubBy
 

--- a/rio/src/RIO/Prelude/Types.hs
+++ b/rio/src/RIO/Prelude/Types.hs
@@ -60,6 +60,9 @@ module RIO.Prelude.Types
     -- *** @Either@
     -- | Re-exported from "Data.Either":
   , Data.Either.Either(..)
+    -- *** @NonEmpty@
+    -- | Re-exported from Data.List.NonEmpty
+  , Data.List.NonEmpty.NonEmpty
     -- *** @Proxy@
     -- | Re-exported from "Data.Proxy":
   , Data.Proxy.Proxy(..)
@@ -171,9 +174,6 @@ module RIO.Prelude.Types
     -- **** @Data@
     -- | Re-exported from "Data.Data":
   , Data.Data.Data(..)
-    -- **** @NonEmpty@
-    -- | Re-exported from Data.List.NonEmpty
-  , Data.List.NonEmpty.NonEmpty
     -- **** @Generic@
     -- | Re-exported from "GHC.Generics":
   , GHC.Generics.Generic

--- a/rio/src/RIO/Prelude/Types.hs
+++ b/rio/src/RIO/Prelude/Types.hs
@@ -62,7 +62,7 @@ module RIO.Prelude.Types
   , Data.Either.Either(..)
     -- *** @NonEmpty@
     -- | Re-exported from Data.List.NonEmpty
-  , Data.List.NonEmpty.NonEmpty
+  , Data.List.NonEmpty.NonEmpty(..)
     -- *** @Proxy@
     -- | Re-exported from "Data.Proxy":
   , Data.Proxy.Proxy(..)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.12
+resolver: lts-13.26
 packages:
 - rio
 - rio-orphans


### PR DESCRIPTION
This PR builds off of #174 , etc., to:

- actually expose the `RIO.NonEmpty.*` modules
- correct some minor documentation issues
- expose the `(:|)` operator after all

Previous work had purposefully left out `(:|)`, citing conflicts with other packages. However, since `NonEmpty` is from `base` and the cited conflicts are not, I believe that the `NonEmpty` version should be considered the "real" one. Note that the vanilla List type itself and its constructors are always exposed regardless of `NoImplicitPrelude`, and so we could argue that its twin (`NonEmpty`) should be exposed in the same way.

I'm willing to reconsider this stance on `(:|)` of course, and have left its addition as the final commit in this PR, to aid a rollback.