### PR TITLE
Bi* Classes

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for rio
 
+## 0.2.0.0
+
+* Expose `Bifunctor`, `Bifoldable`, and `Bitraversable`.
+* The `first` and `second` functions exported by `RIO` formerly originated from
+  `Control.Arrow`. They now come from `Bifunctor`.
+
 ## 0.1.16.0
 
 * Expand the number of `microlens` functions exported by the RIO prelude.

--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for rio
 
-## 0.2.0.0
+## 0.1.17.0
 
 * Expose `Bifunctor`, `Bifoldable`, and `Bitraversable`.
 * The `first` and `second` functions exported by `RIO` formerly originated from

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -1,5 +1,5 @@
 name: rio
-version: 0.2.0.0
+version: 0.1.17.0
 synopsis: A standard library for Haskell
 description: See README and Haddocks at <https://www.stackage.org/package/rio>
 license: MIT

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -1,5 +1,5 @@
 name: rio
-version: 0.1.16.0
+version: 0.2.0.0
 synopsis: A standard library for Haskell
 description: See README and Haddocks at <https://www.stackage.org/package/rio>
 license: MIT

--- a/rio/rio.cabal
+++ b/rio/rio.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           rio
-version:        0.1.16.0
+version:        0.2.0.0
 synopsis:       A standard library for Haskell
 description:    See README and Haddocks at <https://www.stackage.org/package/rio>
 category:       Control

--- a/rio/rio.cabal
+++ b/rio/rio.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           rio
-version:        0.2.0.0
+version:        0.1.17.0
 synopsis:       A standard library for Haskell
 description:    See README and Haddocks at <https://www.stackage.org/package/rio>
 category:       Control

--- a/rio/src/RIO/Prelude.hs
+++ b/rio/src/RIO/Prelude.hs
@@ -270,6 +270,41 @@ module RIO.Prelude
   , Data.Bifunctor.first
   , Data.Bifunctor.second
 
+    -- * @Bifoldable@
+    -- | Re-exported from "Data.Bifoldable":
+  , Data.Bifoldable.bifold
+  , Data.Bifoldable.bifoldMap
+  , Data.Bifoldable.bifoldr
+  , Data.Bifoldable.bifoldl
+  , Data.Bifoldable.bifoldr'
+  , Data.Bifoldable.bifoldr1
+  , Data.Bifoldable.bifoldrM
+  , Data.Bifoldable.bifoldl'
+  , Data.Bifoldable.bifoldl1
+  , Data.Bifoldable.bifoldlM
+  , Data.Bifoldable.bitraverse_
+  , Data.Bifoldable.bifor_
+  , Data.Bifoldable.bisequence_
+  , Data.Bifoldable.biasum
+  , Data.Bifoldable.biList
+  , Data.Bifoldable.binull
+  , Data.Bifoldable.bilength
+  , Data.Bifoldable.bielem
+  , Data.Bifoldable.bimaximum
+  , Data.Bifoldable.biminimum
+  , Data.Bifoldable.bisum
+  , Data.Bifoldable.biproduct
+  , Data.Bifoldable.biconcat
+  , Data.Bifoldable.biconcatMap
+  , Data.Bifoldable.biand
+  , Data.Bifoldable.bior
+  , Data.Bifoldable.biany
+  , Data.Bifoldable.biall
+  , Data.Bifoldable.bimaximumBy
+  , Data.Bifoldable.biminimumBy
+  , Data.Bifoldable.binotElem
+  , Data.Bifoldable.bifind
+
     -- * @MonadPlus@
     -- | Re-exported from "Control.Monad":
   , Control.Monad.mzero
@@ -397,6 +432,7 @@ import qualified Control.Monad
 import qualified Control.Monad.Primitive (primitive)
 import qualified Control.Monad.Reader
 import qualified Control.Monad.ST
+import qualified Data.Bifoldable
 import qualified Data.Bifunctor
 import qualified Data.Bool
 import qualified Data.ByteString.Short

--- a/rio/src/RIO/Prelude.hs
+++ b/rio/src/RIO/Prelude.hs
@@ -264,6 +264,12 @@ module RIO.Prelude
   , Control.Monad.when
   , Control.Monad.unless
 
+    -- * @Bifunctor@
+    -- | Re-exported from "Data.Bifunctor":
+  , Data.Bifunctor.bimap
+  , Data.Bifunctor.first
+  , Data.Bifunctor.second
+
     -- * @MonadPlus@
     -- | Re-exported from "Control.Monad":
   , Control.Monad.mzero
@@ -273,8 +279,6 @@ module RIO.Prelude
 
     -- * @Arrow@
     -- | Re-exported from "Control.Arrow" and "Control.Category":
-  , Control.Arrow.first
-  , Control.Arrow.second
   , (Control.Arrow.&&&)
   , (Control.Arrow.***)
   , (Control.Category.>>>)
@@ -385,61 +389,36 @@ import qualified RIO.Prelude.Renames
 import qualified RIO.Prelude.Text
 import qualified RIO.Prelude.Types
 
-import Prelude ((*))
-import qualified Prelude
-
-import qualified Data.Bool
-
-import qualified Data.Maybe
-
-import qualified Data.Either
-
-import qualified Data.Tuple
-
-import qualified Data.Eq
-
-import qualified Data.Ord
-
-import qualified Data.Word
-
-import qualified Data.Semigroup
-
-import qualified Data.Monoid
-
-import qualified Data.Functor
-
 import qualified Control.Applicative
-
-import qualified Control.Monad
-
-import qualified Data.Foldable
-
-import qualified Data.Traversable
-
 import qualified Control.Arrow
 import qualified Control.Category
-
-import qualified Data.Function
-
-import qualified Data.List
-
-import qualified Data.String
-
-import qualified Text.Show
-
-import qualified Text.Read
-
 import qualified Control.DeepSeq
-
-import qualified Data.Void
-
-import qualified Control.Monad.Reader
-
-import qualified Data.ByteString.Short
-
-import qualified Data.Text.Encoding (decodeUtf8', decodeUtf8With, encodeUtf8,
-                                     encodeUtf8Builder)
-import qualified Data.Text.Encoding.Error (lenientDecode)
-
+import qualified Control.Monad
 import qualified Control.Monad.Primitive (primitive)
+import qualified Control.Monad.Reader
 import qualified Control.Monad.ST
+import qualified Data.Bifunctor
+import qualified Data.Bool
+import qualified Data.ByteString.Short
+import qualified Data.Either
+import qualified Data.Eq
+import qualified Data.Foldable
+import qualified Data.Function
+import qualified Data.Functor
+import qualified Data.List
+import qualified Data.Maybe
+import qualified Data.Monoid
+import qualified Data.Ord
+import qualified Data.Semigroup
+import qualified Data.String
+import qualified Data.Text.Encoding
+    (decodeUtf8', decodeUtf8With, encodeUtf8, encodeUtf8Builder)
+import qualified Data.Text.Encoding.Error (lenientDecode)
+import qualified Data.Traversable
+import qualified Data.Tuple
+import qualified Data.Void
+import qualified Data.Word
+import           Prelude ((*))
+import qualified Prelude
+import qualified Text.Read
+import qualified Text.Show

--- a/rio/src/RIO/Prelude.hs
+++ b/rio/src/RIO/Prelude.hs
@@ -305,6 +305,14 @@ module RIO.Prelude
   , Data.Bifoldable.binotElem
   , Data.Bifoldable.bifind
 
+    -- * @Bitraverse@
+    -- | Re-exported from "Data.Bitraversable":
+  , Data.Bitraversable.bitraverse
+  , Data.Bitraversable.bisequence
+  , Data.Bitraversable.bifor
+  , Data.Bitraversable.bimapAccumL
+  , Data.Bitraversable.bimapAccumR
+
     -- * @MonadPlus@
     -- | Re-exported from "Control.Monad":
   , Control.Monad.mzero
@@ -434,6 +442,7 @@ import qualified Control.Monad.Reader
 import qualified Control.Monad.ST
 import qualified Data.Bifoldable
 import qualified Data.Bifunctor
+import qualified Data.Bitraversable
 import qualified Data.Bool
 import qualified Data.ByteString.Short
 import qualified Data.Either

--- a/rio/src/RIO/Prelude/Types.hs
+++ b/rio/src/RIO/Prelude/Types.hs
@@ -133,6 +133,9 @@ module RIO.Prelude.Types
     -- **** @Functor@
     -- | Re-exported from "Data.Functor":
   , Data.Functor.Functor
+    -- **** @Bifunctor@
+    -- | Re-exported from "Data.Bifunctor":
+  , Data.Bifunctor.Bifunctor
     -- **** @Foldable@
     -- | Re-exported from "Data.Foldable":
   , Data.Foldable.Foldable
@@ -287,17 +290,6 @@ module RIO.Prelude.Types
   , Control.Monad.Primitive.PrimMonad (PrimState)
   ) where
 
-import qualified Control.Monad.Primitive (PrimMonad(..))
-import qualified Data.ByteString (ByteString)
-import qualified Data.ByteString.Builder (Builder)
-import qualified Data.Monoid (Monoid)
-import qualified Data.Semigroup (Semigroup)
-import qualified Data.String (IsString, String)
-import qualified Data.Text (Text)
-import qualified Data.Typeable
-import qualified System.IO
-
-import qualified Data.Vector.Unboxed (Unbox)
 import qualified RIO.Prelude.Renames
 
 import qualified Control.Applicative
@@ -308,9 +300,13 @@ import qualified Control.Exception.Base
 import qualified Control.Monad
 import qualified Control.Monad.Catch
 import qualified Control.Monad.Fail
+import qualified Control.Monad.Primitive (PrimMonad(..))
 import qualified Control.Monad.Reader
 import qualified Control.Monad.ST
+import qualified Data.Bifunctor
 import qualified Data.Bool
+import qualified Data.ByteString (ByteString)
+import qualified Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Short
 import qualified Data.Char
 import qualified Data.Data
@@ -331,14 +327,20 @@ import qualified Data.List
 import qualified Data.List.NonEmpty
 import qualified Data.Map.Strict
 import qualified Data.Maybe
+import qualified Data.Monoid (Monoid)
 import qualified Data.Ord
 import qualified Data.Proxy
 import qualified Data.Ratio
+import qualified Data.Semigroup (Semigroup)
 import qualified Data.Sequence
 import qualified Data.Set
+import qualified Data.String (IsString, String)
+import qualified Data.Text (Text)
 import qualified Data.Text.Encoding.Error
 import qualified Data.Traversable
+import qualified Data.Typeable
 import qualified Data.Vector
+import qualified Data.Vector.Unboxed (Unbox)
 import qualified Data.Void
 import qualified Data.Word
 import qualified Foreign.Storable
@@ -347,8 +349,9 @@ import qualified GHC.Stack
 import qualified Numeric.Natural
 import qualified Prelude
 import qualified System.Exit
+import qualified System.IO
 import qualified Text.Read
 import qualified Text.Show
 
 -- Bring instances for some of the unliftio types in scope, so they can be documented here.
-import UnliftIO ()
+import           UnliftIO ()

--- a/rio/src/RIO/Prelude/Types.hs
+++ b/rio/src/RIO/Prelude/Types.hs
@@ -139,6 +139,9 @@ module RIO.Prelude.Types
     -- **** @Foldable@
     -- | Re-exported from "Data.Foldable":
   , Data.Foldable.Foldable
+    -- **** @Bifoldable@
+    -- | Re-exported from "Data.Bifoldable":
+  , Data.Bifoldable.Bifoldable
     -- **** @Semigroup@
     -- | Re-exported from "Data.Semigroup":
   , Data.Semigroup.Semigroup
@@ -303,6 +306,7 @@ import qualified Control.Monad.Fail
 import qualified Control.Monad.Primitive (PrimMonad(..))
 import qualified Control.Monad.Reader
 import qualified Control.Monad.ST
+import qualified Data.Bifoldable
 import qualified Data.Bifunctor
 import qualified Data.Bool
 import qualified Data.ByteString (ByteString)

--- a/rio/src/RIO/Prelude/Types.hs
+++ b/rio/src/RIO/Prelude/Types.hs
@@ -157,6 +157,9 @@ module RIO.Prelude.Types
     -- **** @Traversable@
     -- | Re-exported from "Data.Traversable":
   , Data.Traversable.Traversable
+    -- **** @Bitraversable@
+    -- | Re-exported from "Data.Bitraversable":
+  , Data.Bitraversable.Bitraversable
     -- **** @Monad@
     -- | Re-exported from "Control.Monad":
   , Control.Monad.Monad
@@ -308,6 +311,7 @@ import qualified Control.Monad.Reader
 import qualified Control.Monad.ST
 import qualified Data.Bifoldable
 import qualified Data.Bifunctor
+import qualified Data.Bitraversable
 import qualified Data.Bool
 import qualified Data.ByteString (ByteString)
 import qualified Data.ByteString.Builder (Builder)


### PR DESCRIPTION
This PR exposes `Bifunctor`, `Bifoldable`, and `Bitraversable`, which are in `base` as of `4.10`. Luckily, `rio` already enforces a `>= 4.10` bound!

**Note:** The `first` and `second` functions from `Control.Arrow`, while the originals, can be considered special cases of those from `Bifunctor`. Specially, the `Bifunctor` variants work on both Tuple and `Either`, while those of Arrow work only on Tuple. So, this PR hides the Arrow variants. 

Functions which have *not* been exposed:

#### Aliases
- `biforM`
- `bimapM`
- `bisequenceA`
- `bimapM_`
- `biforM_`
- `bimsum`
- `bisequenceA_`

#### Pointless?
- `bimapDefault`
- `bifoldMapDefault`