### PR TITLE
Expanding Microlens

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for rio
 
+## 0.1.16.0
+
+* Expand the number of `microlens` functions exported by the RIO prelude.
+* Add new module `RIO.Lens` which provides the rest of `microlens`.
+
 ## 0.1.15.1
 
 * Replace `canonicalizePath` with `makeAbsolute` [#217](https://github.com/commercialhaskell/rio/issues/217)

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -1,5 +1,5 @@
 name: rio
-version: 0.1.15.1
+version: 0.1.16.0
 synopsis: A standard library for Haskell
 description: See README and Haddocks at <https://www.stackage.org/package/rio>
 license: MIT
@@ -63,6 +63,7 @@ library:
     - RIO.HashMap
     - RIO.HashMap.Partial
     - RIO.HashSet
+    - RIO.Lens
     - RIO.List
     - RIO.List.Partial
     - RIO.Map

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -7,6 +7,7 @@ author: Michael Snoyman
 maintainer: michael@snoyman.com
 github: commercialhaskell/rio
 category: Control
+
 extra-source-files:
 - README.md
 - ChangeLog.md
@@ -21,6 +22,7 @@ dependencies:
 - filepath
 - hashable
 - microlens
+- microlens-mtl
 - mtl
 - primitive
 - text

--- a/rio/rio.cabal
+++ b/rio/rio.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 30ccd150c619c6c6fa96ebc7d3b33d6cb4ea1b2e45228e4cba5c35c1bc64cd63
+-- hash: 11b6bee06843c7a494b7af4c3490da6ca8ad82e3a888e9e613de01a9bf75d6ed
 
 name:           rio
 version:        0.1.15.1
@@ -42,6 +42,7 @@ library
       RIO.HashMap
       RIO.HashMap.Partial
       RIO.HashSet
+      RIO.Lens
       RIO.List
       RIO.List.Partial
       RIO.Map
@@ -102,6 +103,7 @@ library
     , filepath
     , hashable
     , microlens
+    , microlens-mtl
     , mtl
     , primitive
     , process
@@ -150,6 +152,7 @@ test-suite spec
     , hashable
     , hspec
     , microlens
+    , microlens-mtl
     , mtl
     , primitive
     , process

--- a/rio/rio.cabal
+++ b/rio/rio.cabal
@@ -3,11 +3,9 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.1.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 11b6bee06843c7a494b7af4c3490da6ca8ad82e3a888e9e613de01a9bf75d6ed
 
 name:           rio
-version:        0.1.15.1
+version:        0.1.16.0
 synopsis:       A standard library for Haskell
 description:    See README and Haddocks at <https://www.stackage.org/package/rio>
 category:       Control

--- a/rio/src/RIO.hs
+++ b/rio/src/RIO.hs
@@ -41,7 +41,8 @@ module RIO
   , module RIO.Prelude.Logger
     -- * Display
   , module RIO.Prelude.Display
-    -- * Lens
+    -- * Optics
+    -- | @microlens@-based Lenses, Traversals, etc.
   , module RIO.Prelude.Lens
     -- * Concurrency
   , UnliftIO.Concurrent.ThreadId

--- a/rio/src/RIO/Lens.hs
+++ b/rio/src/RIO/Lens.hs
@@ -1,4 +1,11 @@
--- | Extra utilities from @microlens@.
+-- |
+-- Module    : RIO.Lens
+-- License   : MIT
+-- Maintainer: Colin Woodbury <colin@fosskers.ca>
+--
+-- Extra utilities from @microlens@.
+--
+-- @since: 0.1.16.0
 module RIO.Lens
   ( -- * Fold
     SimpleFold

--- a/rio/src/RIO/Lens.hs
+++ b/rio/src/RIO/Lens.hs
@@ -1,0 +1,32 @@
+-- | Extra utilities from @microlens@.
+module RIO.Lens
+  ( -- * Fold
+    SimpleFold
+  , toListOf
+  , has
+    -- * Lens
+  , _1, _2, _3, _4, _5
+  , at
+  , lens
+    -- * Iso
+  , non
+    -- * Traversal
+  , singular
+  , failing
+  , filtered
+  , both
+  , traversed
+  , each
+  , ix
+  , _head
+  , _tail
+  , _init
+  , _last
+    -- * Prism
+  , _Left
+  , _Right
+  , _Just
+  , _Nothing
+  ) where
+
+import Lens.Micro

--- a/rio/src/RIO/Prelude/Lens.hs
+++ b/rio/src/RIO/Prelude/Lens.hs
@@ -1,23 +1,51 @@
 module RIO.Prelude.Lens
-  ( view
-  , Lens.Micro.ASetter
-  , Lens.Micro.ASetter'
-  , Lens.Micro.Getting
-  , Lens.Micro.Lens
-  , Lens.Micro.Lens'
-  , Lens.Micro.SimpleGetter
-  , Lens.Micro.lens
-  , Lens.Micro.over
-  , Lens.Micro.set
-  , Lens.Micro.sets
-  , Lens.Micro.to
+  ( -- ** Setter
+    ASetter
+  , ASetter'
+  , (%~)
+  , over
+  , (.~)
+  , set
+  , sets
+    -- ** Getter
+  , SimpleGetter
+  , Getting
   , (Lens.Micro.^.)
+  , view
+  , preview
+  , to
+    -- ** Fold
+  , SimpleFold
+  , (^..)
+  , toListOf
+  , (^?)
+  , has
+    -- ** Lens
+  , Lens
+  , Lens'
+  , _1, _2, _3, _4, _5
+  , at
+  , lens
+    -- ** Iso
+  , non
+    -- ** Traversal
+  , singular
+  , failing
+  , filtered
+  , both
+  , traversed
+  , each
+  , ix
+  , _head
+  , _tail
+  , _init
+  , _last
+    -- ** Prism
+  , _Left
+  , _Right
+  , _Just
+  , _Nothing
   ) where
 
 import Lens.Micro
-import Control.Monad.Reader (MonadReader, asks)
-import           Lens.Micro.Internal      (( #. ))
-import           Control.Applicative      (Const (..))
-
-view :: MonadReader s m => Getting a s a -> m a
-view l = asks (getConst #. l Const)
+import Lens.Micro.Mtl

--- a/rio/src/RIO/Prelude/Lens.hs
+++ b/rio/src/RIO/Prelude/Lens.hs
@@ -1,50 +1,22 @@
 module RIO.Prelude.Lens
-  ( -- ** Setter
-    ASetter
-  , ASetter'
-  , (%~)
-  , over
-  , (.~)
-  , set
-  , sets
-    -- ** Getter
-  , SimpleGetter
-  , Getting
-  , (Lens.Micro.^.)
-  , view
+  ( view
   , preview
-  , to
-    -- ** Fold
-  , SimpleFold
-  , (^..)
-  , toListOf
-  , (^?)
-  , has
-    -- ** Lens
-  , Lens
-  , Lens'
-  , _1, _2, _3, _4, _5
-  , at
-  , lens
-    -- ** Iso
-  , non
-    -- ** Traversal
-  , singular
-  , failing
-  , filtered
-  , both
-  , traversed
-  , each
-  , ix
-  , _head
-  , _tail
-  , _init
-  , _last
-    -- ** Prism
-  , _Left
-  , _Right
-  , _Just
-  , _Nothing
+  , Lens.Micro.ASetter
+  , Lens.Micro.ASetter'
+  , Lens.Micro.Getting
+  , Lens.Micro.Lens
+  , Lens.Micro.Lens'
+  , Lens.Micro.SimpleGetter
+  , Lens.Micro.lens
+  , Lens.Micro.over
+  , Lens.Micro.set
+  , Lens.Micro.sets
+  , Lens.Micro.to
+  , (Lens.Micro.^.)
+  , (Lens.Micro.^?)
+  , (Lens.Micro.^..)
+  , (Lens.Micro.%~)
+  , (Lens.Micro..~)
   ) where
 
 import Lens.Micro


### PR DESCRIPTION
These extended exports should be enough to ensure that most users won't need to depend on `microlens` independently.

Note that I've removed the custom reimplementation of `view`, and instead pulled it from `microlens-mtl`, the transitive deps of which were already in `rio`.