### PR TITLE
Warnings

### DIFF
--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -44,6 +44,14 @@ when:
     dependencies:
     - unix
 
+ghc-options:
+  - -Wall
+  - -Wcompat
+  - -Wpartial-fields
+  - -Wincomplete-record-updates
+  - -Wincomplete-uni-patterns
+  - -Widentities
+
 library:
   source-dirs: src/
   exposed-modules:

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -46,7 +46,6 @@ when:
 
 ghc-options:
   - -Wall
-  - -Wcompat
   - -Wpartial-fields
   - -Wincomplete-record-updates
   - -Wincomplete-uni-patterns

--- a/rio/src/RIO.hs
+++ b/rio/src/RIO.hs
@@ -87,31 +87,29 @@ module RIO
   ) where
 
 import qualified Control.Monad.Catch (MonadThrow(..))
-import RIO.Deque
-import RIO.Prelude
-import RIO.Prelude.Display
-import RIO.Prelude.Exit
-import RIO.Prelude.Extra
-import RIO.Prelude.IO
-import RIO.Prelude.Lens
-import RIO.Prelude.Logger
-import RIO.Prelude.Renames
-import RIO.Prelude.RIO as MonadRIO (RIO(..), liftRIO, runRIO)
-import RIO.Prelude.RIO as SomeRef hiding (RIO(..), liftRIO, runRIO)
-import RIO.Prelude.Simple
-import RIO.Prelude.Text
-import RIO.Prelude.Trace
-import RIO.Prelude.Types
-import RIO.Prelude.URef
-import Control.Monad.IO.Unlift
-import UnliftIO.Async
-import UnliftIO.Chan
-import UnliftIO.Exception
-import UnliftIO.IO
-import UnliftIO.IORef
-import UnliftIO.Memoize
-import UnliftIO.MVar
-import UnliftIO.STM
-import UnliftIO.Temporary
-import UnliftIO.Timeout
-import UnliftIO.Concurrent
+import           Control.Monad.IO.Unlift
+import           RIO.Deque
+import           RIO.Prelude
+import           RIO.Prelude.Display
+import           RIO.Prelude.Exit
+import           RIO.Prelude.IO
+import           RIO.Prelude.Lens
+import           RIO.Prelude.Logger
+import           RIO.Prelude.Renames
+import           RIO.Prelude.RIO as MonadRIO (RIO(..), liftRIO, runRIO)
+import           RIO.Prelude.RIO as SomeRef hiding (RIO(..), liftRIO, runRIO)
+import           RIO.Prelude.Simple
+import           RIO.Prelude.Trace
+import           RIO.Prelude.Types
+import           RIO.Prelude.URef
+import           UnliftIO.Async
+import           UnliftIO.Chan
+import           UnliftIO.Concurrent
+import           UnliftIO.Exception
+import           UnliftIO.IO
+import           UnliftIO.IORef
+import           UnliftIO.Memoize
+import           UnliftIO.MVar
+import           UnliftIO.STM
+import           UnliftIO.Temporary
+import           UnliftIO.Timeout

--- a/rio/src/RIO/Deque.hs
+++ b/rio/src/RIO/Deque.hs
@@ -23,15 +23,15 @@ module RIO.Deque
     , asBDeque
     ) where
 
-import           RIO.Prelude.Reexports
-import           Control.Exception            (assert)
-import           Control.Monad                (liftM)
-import qualified Data.Vector.Generic          as VG
-import qualified Data.Vector.Generic.Mutable  as V
-import qualified Data.Vector.Mutable          as B
-import qualified Data.Vector.Storable.Mutable as S
-import qualified Data.Vector.Unboxed.Mutable  as U
+import           Control.Exception (assert)
+import           Control.Monad (liftM)
 import           Data.Primitive.MutVar
+import qualified Data.Vector.Generic as VG
+import qualified Data.Vector.Generic.Mutable as V
+import qualified Data.Vector.Mutable as B
+import qualified Data.Vector.Storable.Mutable as S
+import qualified Data.Vector.Unboxed.Mutable as U
+import           RIO.Prelude.Reexports
 
 data DequeState v s a = DequeState
     !(v s a)
@@ -274,7 +274,7 @@ dequeToVector :: (VG.Vector v' a, V.MVector v a, PrimMonad m)
 dequeToVector dq = do
     size <- getDequeSize dq
     mv <- V.unsafeNew size
-    foldlDeque (\i e -> V.unsafeWrite mv i e >> pure (i+1)) 0 dq
+    void $ foldlDeque (\i e -> V.unsafeWrite mv i e >> pure (i+1)) 0 dq
     VG.unsafeFreeze mv
 
 
@@ -317,7 +317,7 @@ freezeDeque ::
   => Deque (VG.Mutable v) (PrimState m) a
   -> m (v a)
 freezeDeque (Deque var) = do
-    state@(DequeState v _ size) <- readMutVar var
+    state@(DequeState _ _ size) <- readMutVar var
     v' <- V.unsafeNew size
     makeCopy v' state
     VG.unsafeFreeze v'

--- a/rio/src/RIO/Prelude.hs
+++ b/rio/src/RIO/Prelude.hs
@@ -385,61 +385,35 @@ import qualified RIO.Prelude.Renames
 import qualified RIO.Prelude.Text
 import qualified RIO.Prelude.Types
 
-import Prelude ((*))
-import qualified Prelude
-
-import qualified Data.Bool
-
-import qualified Data.Maybe
-
-import qualified Data.Either
-
-import qualified Data.Tuple
-
-import qualified Data.Eq
-
-import qualified Data.Ord
-
-import qualified Data.Word
-
-import qualified Data.Semigroup
-
-import qualified Data.Monoid
-
-import qualified Data.Functor
-
 import qualified Control.Applicative
-
-import qualified Control.Monad
-
-import qualified Data.Foldable
-
-import qualified Data.Traversable
-
 import qualified Control.Arrow
 import qualified Control.Category
-
-import qualified Data.Function
-
-import qualified Data.List
-
-import qualified Data.String
-
-import qualified Text.Show
-
-import qualified Text.Read
-
 import qualified Control.DeepSeq
-
-import qualified Data.Void
-
-import qualified Control.Monad.Reader
-
-import qualified Data.ByteString.Short
-
-import qualified Data.Text.Encoding (decodeUtf8', decodeUtf8With, encodeUtf8,
-                                     encodeUtf8Builder)
-import qualified Data.Text.Encoding.Error (lenientDecode)
-
+import qualified Control.Monad
 import qualified Control.Monad.Primitive (primitive)
+import qualified Control.Monad.Reader
 import qualified Control.Monad.ST
+import qualified Data.Bool
+import qualified Data.ByteString.Short
+import qualified Data.Either
+import qualified Data.Eq
+import qualified Data.Foldable
+import qualified Data.Function
+import qualified Data.Functor
+import qualified Data.List
+import qualified Data.Maybe
+import qualified Data.Monoid
+import qualified Data.Ord
+import qualified Data.Semigroup
+import qualified Data.String
+import qualified Data.Text.Encoding
+    (decodeUtf8', decodeUtf8With, encodeUtf8, encodeUtf8Builder)
+import qualified Data.Text.Encoding.Error (lenientDecode)
+import qualified Data.Traversable
+import qualified Data.Tuple
+import qualified Data.Void
+import qualified Data.Word
+import           Prelude ((*))
+import qualified Prelude
+import qualified Text.Read
+import qualified Text.Show

--- a/rio/src/RIO/Prelude/Extra.hs
+++ b/rio/src/RIO/Prelude/Extra.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP          #-}
 module RIO.Prelude.Extra
   ( mapLeft
   , fromFirst
@@ -15,13 +15,15 @@ module RIO.Prelude.Extra
   , asIO
   ) where
 
-import Prelude
+import           Control.Monad
+import           Data.Foldable (foldlM)
+#if MIN_VERSION_base(4,11,0)
+import           Data.Functor ((<&>))
+#endif
+import           Data.Maybe
+import           Data.Monoid (First(..))
 import qualified Data.Set as Set
-import Data.Monoid (First (..))
-import Data.Foldable (foldlM)
-import Data.Functor
-import Data.Maybe
-import Control.Monad
+import           Prelude
 
 -- | Apply a function to a 'Left' constructor
 mapLeft :: (a1 -> a2) -> Either a1 b -> Either a2 b

--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -52,7 +52,6 @@ module RIO.Prelude.Logger
   ) where
 
 import RIO.Prelude.Reexports hiding ((<>))
-import RIO.Prelude.Renames
 import RIO.Prelude.Display
 import RIO.Prelude.Lens
 import Data.Text (Text)
@@ -619,14 +618,14 @@ utf8CharacterCount = go 0
   where
     go !n bs = case B.uncons bs of
         Nothing -> n
-        Just (c,bs)
-            | c .&. 0xC0 == 0x80 -> go n bs            -- UTF-8 continuation
-            | c == 0x1B          -> go n $ dropCSI bs  -- ANSI escape
-            | otherwise          -> go (n+1) bs
+        Just (c,rest)
+            | c .&. 0xC0 == 0x80 -> go n rest            -- UTF-8 continuation
+            | c == 0x1B          -> go n $ dropCSI rest  -- ANSI escape
+            | otherwise          -> go (n+1) rest
 
     dropCSI bs = case B.uncons bs of
-        Just (0x5B,bs2) -> B.drop 1 $ B.dropWhile isSequenceByte bs2
-        _               -> bs
+        Just (0x5B,rest) -> B.drop 1 $ B.dropWhile isSequenceByte rest
+        _                -> bs
 
     isSequenceByte c = c >= 0x20 && c <= 0x3F
 

--- a/rio/src/RIO/Prelude/RIO.hs
+++ b/rio/src/RIO/Prelude/RIO.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE FunctionalDependencies     #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
 module RIO.Prelude.RIO
   ( RIO (..)
   , runRIO
@@ -21,11 +23,11 @@ module RIO.Prelude.RIO
 
 import GHC.Exts (RealWorld)
 
-import RIO.Prelude.Lens
-import RIO.Prelude.URef
-import RIO.Prelude.Reexports
 import Control.Monad.State (MonadState(..))
 import Control.Monad.Writer (MonadWriter(..))
+import RIO.Prelude.Lens
+import RIO.Prelude.Reexports
+import RIO.Prelude.URef
 
 -- | The Reader+IO monad. This is different from a 'ReaderT' because:
 --
@@ -42,7 +44,9 @@ instance Semigroup a => Semigroup (RIO env a) where
   (<>) = liftA2 (<>)
 instance Monoid a => Monoid (RIO env a) where
   mempty = pure mempty
+#if !MIN_VERSION_base(4,11,0)
   mappend = liftA2 mappend
+#endif
 
 -- | Using the environment run in IO the action that requires that environment.
 --

--- a/rio/src/RIO/Prelude/Renames.hs
+++ b/rio/src/RIO/Prelude/Renames.hs
@@ -11,15 +11,14 @@ module RIO.Prelude.Renames
   , yieldThread
   ) where
 
-import Prelude
-import qualified Data.ByteString          as B
-import qualified Data.ByteString.Lazy     as BL
-import qualified Data.Vector.Generic      as GVector
-import qualified Data.Vector.Storable     as SVector
-import qualified Data.Vector.Unboxed      as UVector
-import qualified Data.Text.Lazy           as TL
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Semigroup
-import UnliftIO (MonadIO)
+import qualified Data.Text.Lazy as TL
+import qualified Data.Vector.Generic as GVector
+import qualified Data.Vector.Storable as SVector
+import qualified Data.Vector.Unboxed as UVector
+import           UnliftIO (MonadIO)
 import qualified UnliftIO.Concurrent (yield)
 
 sappend :: Data.Semigroup.Semigroup s => s -> s -> s

--- a/rio/src/RIO/Prelude/Types.hs
+++ b/rio/src/RIO/Prelude/Types.hs
@@ -317,7 +317,6 @@ import qualified Data.Data
 import qualified Data.Either
 import qualified Data.Eq
 import qualified Data.Foldable
-import qualified Data.Function
 import qualified Data.Functor
 import qualified Data.Functor.Const
 import qualified Data.Functor.Identity
@@ -327,7 +326,6 @@ import qualified Data.HashSet
 import qualified Data.Int
 import qualified Data.IntMap.Strict
 import qualified Data.IntSet
-import qualified Data.List
 import qualified Data.List.NonEmpty
 import qualified Data.Map.Strict
 import qualified Data.Maybe
@@ -346,9 +344,8 @@ import qualified GHC.Generics
 import qualified GHC.Stack
 import qualified Numeric.Natural
 import qualified Prelude
-import qualified System.Exit
 import qualified Text.Read
 import qualified Text.Show
 
 -- Bring instances for some of the unliftio types in scope, so they can be documented here.
-import UnliftIO ()
+import           UnliftIO ()

--- a/rio/test/RIO/DequeSpec.hs
+++ b/rio/test/RIO/DequeSpec.hs
@@ -1,17 +1,16 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module RIO.DequeSpec (spec) where
 
-import RIO
-import Test.Hspec
-import Test.Hspec.QuickCheck
-import Test.QuickCheck.Arbitrary
-import Test.QuickCheck.Gen
 import qualified Data.Vector as VB
 import qualified Data.Vector.Generic as VG
-import qualified Data.Vector.Unboxed as VU
 import qualified Data.Vector.Storable as VS
-import qualified Data.Vector.Generic.Mutable as V
+import qualified Data.Vector.Unboxed as VU
+import           RIO
+import           Test.Hspec
+import           Test.Hspec.QuickCheck
+import           Test.QuickCheck.Arbitrary
+import           Test.QuickCheck.Gen
 
 data DequeAction
     = PushFront Int
@@ -73,7 +72,7 @@ spec = do
               actual <- popBackDeque tested
               actual `shouldBe` expected
               case actual of
-                Just _ -> drain
+                Just _  -> drain
                 Nothing -> return $! ()
         drain
       test name proxy = describe name $ do
@@ -115,7 +114,7 @@ same ::
   -> IORef [Int]
   -> Deque (VG.Mutable v) (PrimState IO) Int
   -> IO ()
-same proxy ref deque = do
+same _ ref deque = do
   fromRef <- readIORef ref
   fromRight <- foldrDeque (\i rest -> pure $ i : rest) [] deque
   fromRight `shouldBe` fromRef


### PR DESCRIPTION
This PR turns on the canonical warning flags recommended by RIO, and fixes what's revealed.

Note: I'm getting these strange warnings left over.
```
/home/colin/code/haskell/rio/rio/src/RIO/Prelude.hs:3:5-28: warning: [-Wdodgy-exports]
    The export item ‘module RIO.Prelude.Types’ exports nothing
  |
3 |     module RIO.Prelude.Types
  |     ^^^^^^^^^^^^^^^^^^^^^^^^
/home/colin/code/haskell/rio/rio/src/RIO/Prelude.hs:386:1-34: warning: [-Wunused-imports]
    The qualified import of ‘RIO.Prelude.Types’ is redundant
    |
386 | import qualified RIO.Prelude.Types
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
despite the fact that `RIO.Prelude.Types` clearly exports a lot. Throwing `NoImplicitPrelude` around doesn't seem to help. I'm going to test elsewhere whether this is a bug with `-Wdodge-exports`.