### PR TITLE
exporting 'empty' for 'class Applicative f => Alternative f'

### DIFF
--- a/rio/src/RIO/Prelude.hs
+++ b/rio/src/RIO/Prelude.hs
@@ -256,6 +256,7 @@ module RIO.Prelude
     -- * @Alternative@
     -- | Re-exported from "Control.Applicative":
   , (Control.Applicative.<|>)
+  , Control.Applicative.empty
   , Control.Applicative.some
   , Control.Applicative.many
   , Control.Applicative.optional


### PR DESCRIPTION
Prelude wasn't exporting `empty` for `class Alternative f` so this one-line change adds that to the `Prelude.hs` re-export of the `Control.Applicative` module.