### PR TITLE
Add generic logging

### DIFF
--- a/rio/src/RIO.hs
+++ b/rio/src/RIO.hs
@@ -37,6 +37,7 @@ module RIO
     -- * @MonadIO@ and @MonadUnliftIO@
   , module Control.Monad.IO.Unlift
     -- * Logger
+    -- $logging-intro
   , module RIO.Prelude.Logger
     -- * Display
   , module RIO.Prelude.Display
@@ -115,3 +116,24 @@ import UnliftIO.STM
 import UnliftIO.Temporary
 import UnliftIO.Timeout
 import UnliftIO.Concurrent
+
+--------------------------------------------------------------------------------
+-- $logging-intro
+--
+-- The logging system in RIO is built upon "log functions", which are
+-- accessed in RIO's environment via a class like "has log
+-- function". There are two provided:
+--
+-- * In the common case: for logging plain text (via 'Utf8Builder')
+--   efficiently, there is 'LogFunc', which can be created via
+--   'withLogFunc', and is accessed via 'HasLogFunc'. This provides
+--   all the classical logging facilities: timestamped text output
+--   with log levels and colors (if terminal-supported) to the
+--   terminal. We log output via 'logInfo', 'logDebug', etc.
+--
+-- * In the advanced case: where logging takes on a more semantic
+--   meaning and the logs need to be digested, acted upon, translated
+--   or serialized upstream (to e.g. a JSON logging server), we have
+--   'GLogFunc' (as in "generic log function"), and is accessed via
+--   'HasGLogFunc'. In this case, we log output via 'glog'. See the
+--   Type-generic logger section for more information.

--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -71,7 +71,6 @@ import RIO.Prelude.Reexports hiding ((<>))
 import RIO.Prelude.Renames
 import RIO.Prelude.Display
 import RIO.Prelude.Lens
-import Data.Functor.Contravariant
 import Data.Text (Text)
 import qualified Data.Text as T
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -88,6 +87,10 @@ import qualified Data.ByteString as B
 import           System.IO                  (localeEncoding)
 import           GHC.Foreign                (peekCString, withCString)
 import Data.Semigroup (Semigroup (..))
+
+#if MIN_VERSION_base(4,12,0)
+import Data.Functor.Contravariant
+#endif
 
 -- | The log level of a message.
 --

--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -713,12 +713,18 @@ instance HasGLogFunc (GLogFunc msg) where
 -- @since 0.1.12.0
 newtype GLogFunc msg = GLogFunc (CallStack -> msg -> IO ())
 
+#if MIN_VERSION_base(4,12,0)
+-- https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Functor-Contravariant.html
+
 -- | Use this instance to wrap sub-loggers via 'RIO.mapRIO'.
+--
+-- The 'Contravariant' class is available in base 4.12.0.
 --
 -- @since 0.1.12.0
 instance Contravariant GLogFunc where
   contramap f (GLogFunc io) = GLogFunc (\stack msg -> io stack (f msg))
   {-# INLINABLE contramap #-}
+#endif
 
 -- | Perform both sets of actions per log entry.
 --
@@ -752,6 +758,7 @@ glog ::
 glog t = do
   GLogFunc gLogFunc <- view gLogFuncL
   liftIO (gLogFunc callStack t)
+{-# INLINABLE glog #-}
 
 --------------------------------------------------------------------------------
 -- Integration with classical logger framework

--- a/rio/src/RIO/Prelude/RIO.hs
+++ b/rio/src/RIO/Prelude/RIO.hs
@@ -8,6 +8,7 @@ module RIO.Prelude.RIO
   ( RIO (..)
   , runRIO
   , liftRIO
+  , mapRIO
   -- SomeRef for Writer/State interfaces
   , SomeRef
   , HasStateRef (..)
@@ -57,6 +58,12 @@ liftRIO :: (MonadIO m, MonadReader env m) => RIO env a -> m a
 liftRIO rio = do
   env <- ask
   runRIO env rio
+
+-- | Lift one RIO env to another.
+mapRIO :: (outer -> inner) -> RIO inner a -> RIO outer a
+mapRIO f m = do
+  outer <- ask
+  runRIO (f outer) m
 
 instance MonadUnliftIO (RIO env) where
     askUnliftIO = RIO $ ReaderT $ \r ->

--- a/rio/src/RIO/Prelude/RIO.hs
+++ b/rio/src/RIO/Prelude/RIO.hs
@@ -60,6 +60,8 @@ liftRIO rio = do
   runRIO env rio
 
 -- | Lift one RIO env to another.
+--
+-- @since 0.1.12.0
 mapRIO :: (outer -> inner) -> RIO inner a -> RIO outer a
 mapRIO f m = do
   outer <- ask


### PR DESCRIPTION
This PR adds generic logging to RIO such that you can log any data type rather than just `Utf8Builder`, and you don't have to decide what log level or format your logs are going to be until later. This is not intended as a replacement for RIO's existing logger, but rather allows different backends to be used, including the "classic" logger. 

Many apps I write might want to log in different ways with non trivial filtering of the logs, with sublogging, and I don't necessarily know right away what levels my logs should be at the call site (it might depend on context). Going through a data type isn't necessarily as fast as going straight to `Utf8Builder`, but that's a conscious trade-off. Idiom is an example of such an app that is using this.

(**Aside**: This PR isn't meant to address various perf. improvement techniques, but if you are really suffering from log speeds and still want to use a generic data type, you have the option to use a newtype wrapper around `Utf8Builder`, and `PatternSynonyms` which immediately render to the `Utf8Builder`. This would be an advanced case. Alternatively, you could experiment with `INLINE` with the intention of having the compiler bypass allocation of the constructor altogether.)

Example:

```haskell
{-# LANGUAGE StandaloneDeriving #-}
{-# LANGUAGE DeriveGeneric #-}
{-# LANGUAGE OverloadedStrings #-}

import           Data.Aeson
import qualified Data.ByteString.Lazy.Char8 as L8
import           GHC.Stack
import           RIO

data Msg
  = DoThis
  | DidThat Double

-- Only needed for JSON logger

  deriving (Generic)
instance ToJSON Msg

-- Only needed to use RIO's classic logger

instance Display Msg where
  display DoThis = "Do this!"
  display (DidThat i) = " ... did that: " <> display i

instance HasLogLevel Msg where
  getLogLevel DoThis = LevelDebug
  getLogLevel DidThat {} = LevelInfo

instance HasLogSource Msg where
  getLogSource _ = "Msg"

main :: IO ()
main = do
  -- Terminal logging:
  logOptions <- logOptionsHandle stderr True
  withLogFunc
    logOptions
    (\logFunc ->
       runRIO
         (gLogFuncClassic logFunc)
         app)
  -- JSON logging:
  runRIO gLogFuncJSON app

-- App that doesn't care how its messages are logged.
app :: RIO (GLogFunc Msg) ()
app = do
  glog DoThis
  glog (DidThat 123.23)

-- Example JSON logger thrown together for this demo (imagine a service receiving this on a socket)

gLogFuncJSON :: ToJSON msg => GLogFunc msg
gLogFuncJSON =
  mkGLogFunc
    (\stack msg ->
       L8.putStrLn
         (encode (object ["origin" .= stackToJSON stack, "msg" .= toJSON msg])))

stackToJSON :: CallStack -> Value
stackToJSON cs =
  case reverse $ getCallStack cs of
    [] -> Null
    (_desc, loc):_ ->
      let file = srcLocFile loc
       in object
            [ "file" .= file
            , "line" .= srcLocStartLine loc
            , "column" .= srcLocStartCol loc
            ]
```

Example output:

```
> main
2019-12-04 11:36:36.398755: [debug] Do this!
@(/home/chris/Work/fpco/idiom/src/ddemo.hs:42:3)
2019-12-04 11:36:36.398903: [info]  ... did that: 123.23
@(/home/chris/Work/fpco/idiom/src/ddemo.hs:43:3)
{"origin":{"line":42,"column":3,"file":"/home/chris/Work/fpco/idiom/src/ddemo.hs"},"msg":{"tag":"DoThis"}}
{"origin":{"line":43,"column":3,"file":"/home/chris/Work/fpco/idiom/src/ddemo.hs"},"msg":{"tag":"DidThat","contents":123.23}}
```