### PR TITLE
Document log source

### DIFF
--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -35,6 +35,8 @@ module RIO.Prelude.Logger
   , logSticky
   , logStickyDone
     -- *** With source
+    --
+    -- $withSource
   , logDebugS
   , logInfoS
   , logWarnS
@@ -203,6 +205,37 @@ logOther
   -> Utf8Builder
   -> m ()
 logOther = logGeneric "" . LevelOther
+
+-- $withSource
+--
+-- There is a set of logging functions that take an extra 'LogSource'
+-- argument to provide context, typically detailing what part of an
+-- application the message comes from.
+--
+-- The built-in log functions as constructed with 'withLogFunc' and
+-- 'LogOptions' ignore the source argument. To make use of it, define
+-- a custom log function along the lines of:
+--
+-- > mkCustomLogFunc :: Handle -> LogFunc
+-- > mkCustomLogFunc handle = mkLogFunc printLog
+-- >   where
+-- >     printLog _cs src level msg =
+-- >       hPutBuilder handle $ getUtf8Builder $
+-- >       displayLevel level <> displaySource src <> msg
+-- >     displayLevel level = case level of
+-- >       LevelDebug -> "[debug] "
+-- >       LevelInfo -> "[info] "
+-- >       LevelWarn -> "[warn] "
+-- >       LevelError -> "[error] "
+-- >       LevelOther name -> "[" <> display name <> "] "
+-- >     displaySource src = case src of
+-- >       "" -> ""
+-- >       _ -> display src <> ": "
+--
+-- With this log function, @infoLogS "database" "connected"@ would
+-- result in
+--
+-- > [info] database: connected
 
 -- | Log a debug level message with the given source.
 --

--- a/rio/test/RIO/LoggerSpec.hs
+++ b/rio/test/RIO/LoggerSpec.hs
@@ -74,3 +74,9 @@ spec = do
       logInfo "should be formatted"
     builder <- readIORef ref
     toLazyByteString builder `shouldBe` "[context] should be formatted\n"
+  it "noSource" $ do
+    (ref, options) <- logOptionsMemory
+    withLogFunc (options & setLogVerboseFormat True) $ \lf -> runRIO lf $ do
+      logInfoS "tests" "should appear"
+    builder <- readIORef ref
+    toLazyByteString builder `shouldBe` "[info] should appear\n"


### PR DESCRIPTION
This is to address #213.

I fear it rather shows up the limits of the current API rather than provide a really useful example, but I suppose that's helpful for the reader anyway.