### PR TITLE
Change log functions to print the LogSource argument

### DIFF
--- a/rio/test/RIO/LoggerSpec.hs
+++ b/rio/test/RIO/LoggerSpec.hs
@@ -74,3 +74,15 @@ spec = do
       logInfo "should be formatted"
     builder <- readIORef ref
     toLazyByteString builder `shouldBe` "[context] should be formatted\n"
+  it "noSource" $ do
+    (ref, options) <- logOptionsMemory
+    withLogFunc options $ \lf -> runRIO lf $ do
+      logInfoS "tests" "should appear"
+    builder <- readIORef ref
+    toLazyByteString builder `shouldBe` "(tests) should appear\n"
+  it "noSource verbose" $ do
+    (ref, options) <- logOptionsMemory
+    withLogFunc (options & setLogVerboseFormat True) $ \lf -> runRIO lf $ do
+      logInfoS "tests" "should appear"
+    builder <- readIORef ref
+    toLazyByteString builder `shouldBe` "[info] (tests) should appear\n"


### PR DESCRIPTION
In both default and verbose mode, providing a non-empty source <src> will
qualify a message \<msg\> as "(\<src\>) \<msg\>".

Instead of #215.