### PR TITLE
Add colours to the `LogOption` constructor

### DIFF
--- a/rio/src/RIO/Process.hs
+++ b/rio/src/RIO/Process.hs
@@ -407,9 +407,10 @@ withProcessTimeLog mdir name args proc' = do
   end <- getMonotonicTime
   let diff = end - start
   useColor <- view logFuncUseColorL
+  accentColors <- view logFuncAccentColorsL
   logDebug
       ("Process finished in " <>
-      (if useColor then "\ESC[92m" else "") <> -- green
+      (if useColor then accentColors 0 else "") <> -- accent color 0
       timeSpecMilliSecondText diff <>
       (if useColor then "\ESC[0m" else "") <> -- reset
        ": " <> display cmdText)


### PR DESCRIPTION
The motivation for this pull request is that the exisitng hard-coded colours in `RIO.Process.withProcessTimeLog` and `RIO.Prelude.Logger.simpleLogFunc` (for timestamps and locs) are not visible when using the Solarised Dark theme.

Tested on Windows 10 by sucessfully rebuilding `stack` (which depends on `rio`), with and without making use of the option to customise logger colours.

The defaults are the same as what was previously hard-coded and `RIO.Prelude.Logger` does not export the constructor of `LogOption`, so existing code depending on `rio` should not be affected.

A new `LogColors` type is exported, and an associated accessor (`logFuncColorsL`):

```haskell
data LogColors = LogColors
  { -- | The color associated with each 'LogLevel'.
    logColorLogLevels :: !(LogLevel -> Utf8Builder)
    -- | The color of secondary content.
  , logColorSecondary :: !Utf8Builder
    -- | The color of accents, which are indexed by 'Int'.
  , logColorAccents :: !(Int -> Utf8Builder)
  }
```

timestamps and locs in `simpleLogFunc` use the colour of secondary content. `withProcessTimeLog` uses accent colour 0 to highlight the duration time.