### PR TITLE
Update rio-orphans README.md for v0.1.1.0

### DIFF
--- a/rio-orphans/README.md
+++ b/rio-orphans/README.md
@@ -2,7 +2,8 @@
 
 Provides orphan instances for the `RIO` data type. Currently supports:
 
-* `MonadCatch` and `MonadMask` from `exceptions`
 * `MonadBase` from `transformers-base`
 * `MonadBaseControl` from `monad-control`
+* `MonadCatch` and `MonadMask` from `exceptions`
+* `MonadLogger` from `monad-logger`
 * `MonadResource` from `resourcet`


### PR DESCRIPTION
See the `rio-orphans` `ChangeLog.md` for v0.1.1.0 changes.

Also lists the items by alphabetical order.