### PR TITLE
Expose `fromLeft` and `fromRight` from `RIO.Prelude`

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio
 
+## 0.1.19.0
+
+* Expose `fromLeft` and `fromRight`
+
 ## 0.1.18.0
 
 * Add colours to the `LogOption` constructor [#222](https://github.com/commercialhaskell/rio/pull/222)

--- a/rio/src/RIO/Prelude.hs
+++ b/rio/src/RIO/Prelude.hs
@@ -28,6 +28,8 @@ module RIO.Prelude
     -- * @Either@
     -- | Re-exported from "Data.Either":
   , Data.Either.either
+  , Data.Either.fromLeft
+  , Data.Either.fromRight
   , Data.Either.isLeft
   , Data.Either.isRight
   , RIO.Prelude.Extra.mapLeft


### PR DESCRIPTION
These guys have been available since base-4.10 which is already the lower bound for rio.