### PR TITLE
A (draft of a) mixin-based template

### DIFF
--- a/etc/mixin-template/.gitignore
+++ b/etc/mixin-template/.gitignore
@@ -1,0 +1,4 @@
+*~
+*.swp
+tarballs/
+.stack-work/

--- a/etc/mixin-template/ChangeLog.md
+++ b/etc/mixin-template/ChangeLog.md
@@ -1,0 +1,3 @@
+# Changelog for PROJECTNAME
+
+## Unreleased changes

--- a/etc/mixin-template/LICENSE
+++ b/etc/mixin-template/LICENSE
@@ -1,0 +1,30 @@
+Copyright AUTHOR (c) 2019
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Author name here nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/etc/mixin-template/README.md
+++ b/etc/mixin-template/README.md
@@ -1,0 +1,10 @@
+# PROJECTNAME
+
+## Execute  
+
+* Run `stack exec -- {{name}}-exe` to see "We're inside the application!"
+* With `stack exec -- {{name}}-exe --verbose` you will see the same message, with more logging.
+
+## Run tests
+
+`stack test`

--- a/etc/mixin-template/Setup.hs
+++ b/etc/mixin-template/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/etc/mixin-template/app/Main.hs
+++ b/etc/mixin-template/app/Main.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Main (main) where
+
+import Import
+import Run
+import Prelude.Process
+import Options.Applicative.Simple
+import qualified Paths_PROJECTNAME
+
+main :: IO ()
+main = do
+  (options, ()) <- simpleOptions
+    $(simpleVersion Paths_PROJECTNAME.version)
+    "Header for command line arguments"
+    "Program description, also for command line arguments"
+    (Options
+       <$> switch ( long "verbose"
+                 <> short 'v'
+                 <> help "Verbose output?"
+                  )
+    )
+    empty
+  lo <- logOptionsHandle stderr (optionsVerbose options)
+  pc <- mkDefaultProcessContext
+  withLogFunc lo $ \lf ->
+    let app = App
+          { appLogFunc = lf
+          , appProcessContext = pc
+          , appOptions = options
+          }
+     in runRIO app run

--- a/etc/mixin-template/package.yaml
+++ b/etc/mixin-template/package.yaml
@@ -1,0 +1,117 @@
+name:                PROJECTNAME
+version:             0.1.0.0
+github:              GITHUB
+license:             BSD3
+author:              AUTHOR
+maintainer:          MAINTAINER
+copyright:           COPYRIGHT
+
+extra-source-files:
+- README.md
+- ChangeLog.md
+
+# Metadata used when publishing your package
+# synopsis:            Short description of your package
+# category:            Web
+
+# To avoid duplicated efforts in documentation and dealing with the
+# complications of embedding Haddock markup inside cabal files, it is
+# common to point users to the README.md file.
+description:         DESCRIPTION
+
+dependencies:
+  - name: base
+    version: ">= 4.11 && <10"
+    mixin: &base-mixin
+      - hiding (Prelude)
+  - name: rio
+    version: ">= 0.1.12.0"
+    mixin: &rio-mixin
+      - (RIO as RIO)
+      - (RIO.List                     as Prelude.List)
+      - (RIO.ByteString               as Prelude.ByteString)
+      - (RIO.ByteString.Lazy          as Prelude.ByteString.Lazy)
+      - (RIO.ByteString.Lazy.Partial  as Prelude.ByteString.Lazy.Partial)
+      - (RIO.ByteString.Partial       as Prelude.ByteString.Partial)
+      - (RIO.Char                     as Prelude.Char)
+      - (RIO.Char.Partial             as Prelude.Char.Partial)
+      - (RIO.Deque                    as Prelude.Deque)
+      - (RIO.Directory                as Prelude.Directory)
+      - (RIO.File                     as Prelude.File)
+      - (RIO.FilePath                 as Prelude.FilePath)
+      - (RIO.HashMap                  as Prelude.HashMap)
+      - (RIO.HashMap.Partial          as Prelude.HashMap.Partial)
+      - (RIO.HashSet                  as Prelude.HashSet)
+      - (RIO.List                     as Prelude.List)
+      - (RIO.List.Partial             as Prelude.List.Partial)
+      - (RIO.Map                      as Prelude.Map)
+      - (RIO.Map.Partial              as Prelude.Map.Partial)
+      - (RIO.Map.Unchecked            as Prelude.Map.Unchecked)
+      - (RIO.NonEmpty                 as Prelude.NonEmpty)
+      - (RIO.NonEmpty.Partial         as Prelude.NonEmpty.Partial)
+      - (RIO.Partial                  as Prelude.Partial)
+      - (RIO.Prelude                  as Prelude.Prelude)
+      - (RIO.Prelude.Simple           as Prelude.Prelude.Simple)
+      - (RIO.Prelude.Types            as Prelude.Prelude.Types)
+      - (RIO.Process                  as Prelude.Process)
+      - (RIO.Seq                      as Prelude.Seq)
+      - (RIO.Set                      as Prelude.Set)
+      - (RIO.Set.Partial              as Prelude.Set.Partial)
+      - (RIO.Set.Unchecked            as Prelude.Set.Unchecked)
+      - (RIO.State                    as Prelude.State)
+      - (RIO.Text                     as Prelude.Text)
+      - (RIO.Text.Lazy                as Prelude.Text.Lazy)
+      - (RIO.Text.Lazy.Partial        as Prelude.Text.Lazy.Partial)
+      - (RIO.Text.Partial             as Prelude.Text.Partial)
+      - (RIO.Time                     as Prelude.Time)
+      - (RIO.Vector                   as Prelude.Vector)
+      - (RIO.Vector.Boxed             as Prelude.Vector.Boxed)
+      - (RIO.Vector.Boxed.Partial     as Prelude.Vector.Boxed.Partial)
+      - (RIO.Vector.Boxed.Unsafe      as Prelude.Vector.Boxed.Unsafe)
+      - (RIO.Vector.Partial           as Prelude.Vector.Partial)
+      - (RIO.Vector.Storable          as Prelude.Vector.Storable)
+      - (RIO.Vector.Storable.Partial  as Prelude.Vector.Storable.Partial)
+      - (RIO.Vector.Storable.Unsafe   as Prelude.Vector.Storable.Unsafe)
+      - (RIO.Vector.Unboxed           as Prelude.Vector.Unboxed)
+      - (RIO.Vector.Unboxed.Partial   as Prelude.Vector.Unboxed.Partial)
+      - (RIO.Vector.Unboxed.Unsafe    as Prelude.Vector.Unboxed.Unsafe)
+      - (RIO.Vector.Unsafe            as Prelude.Vector.Unsafe)
+      - (RIO.Writer                   as Prelude.Writer)
+
+ghc-options:
+- -Wall
+- -Wcompat
+- -Widentities
+- -Wincomplete-record-updates
+- -Wincomplete-uni-patterns
+- -Wpartial-fields
+- -Wredundant-constraints
+
+library:
+  source-dirs: src
+
+executables:
+  PROJECTNAME-exe:
+    main:                Main.hs
+    source-dirs:         app
+    dependencies:
+    - PROJECTNAME
+    - optparse-simple
+
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+
+tests:
+  PROJECTNAME-test:
+    main:                Spec.hs
+    source-dirs:         test
+    dependencies:
+    - PROJECTNAME
+    - hspec
+
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N

--- a/etc/mixin-template/src/Import.hs
+++ b/etc/mixin-template/src/Import.hs
@@ -1,0 +1,5 @@
+module Import
+  ( module Types
+  ) where
+
+import Types

--- a/etc/mixin-template/src/Prelude.hs
+++ b/etc/mixin-template/src/Prelude.hs
@@ -1,0 +1,6 @@
+module Prelude
+    ( module RIO
+    )
+    where
+
+import RIO hiding (catchIO)

--- a/etc/mixin-template/src/Run.hs
+++ b/etc/mixin-template/src/Run.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Run (run) where
+
+import Import
+
+run :: RIO App ()
+run = do
+  logInfo "We're inside the application!"

--- a/etc/mixin-template/src/Types.hs
+++ b/etc/mixin-template/src/Types.hs
@@ -1,0 +1,20 @@
+module Types where
+
+import Prelude.Process
+
+-- | Command line arguments
+data Options = Options
+  { optionsVerbose :: !Bool
+  }
+
+data App = App
+  { appLogFunc :: !LogFunc
+  , appProcessContext :: !ProcessContext
+  , appOptions :: !Options
+  -- Add other app-specific configuration information here
+  }
+
+instance HasLogFunc App where
+  logFuncL = lens appLogFunc (\x y -> x { appLogFunc = y })
+instance HasProcessContext App where
+  processContextL = lens appProcessContext (\x y -> x { appProcessContext = y })

--- a/etc/mixin-template/src/Util.hs
+++ b/etc/mixin-template/src/Util.hs
@@ -1,0 +1,8 @@
+-- | Silly utility module, used to demonstrate how to write a test
+-- case.
+module Util
+  ( plus2
+  ) where
+
+plus2 :: Int -> Int
+plus2 = (+ 2)

--- a/etc/mixin-template/test/Spec.hs
+++ b/etc/mixin-template/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/etc/mixin-template/test/UtilSpec.hs
+++ b/etc/mixin-template/test/UtilSpec.hs
@@ -1,0 +1,13 @@
+module UtilSpec (spec) where
+
+import Import
+import Util
+import Test.Hspec
+import Test.Hspec.QuickCheck
+
+spec :: Spec
+spec = do
+  describe "plus2" $ do
+    it "basic check" $ plus2 0 `shouldBe` 2
+    it "overflow" $ plus2 maxBound `shouldBe` minBound + 1
+    prop "minus 2" $ \i -> plus2 i - 2 `shouldBe` i


### PR DESCRIPTION
Cabal 2.0/GHC 8.2 (and later) support mixins to rename, show, and hide modules.

We can use those mixins to not have to use `NoImplicitPrelude` and instead treat RIO as a 'true' Prelude-replacement, i.e. changing the import Path to `Prelude`-prefixed so instead of `import RIO.File` one uses `import Prelude.File`.

While this may not be the best way of using RIO it is basically how I've been using RIO in my private projects and I wanted to show this way in case anybody else finds it interesting.
The actual code itself could also be improved a lot but I kept as close as possible to the original template this was copied from to make the differences obvious.
Biggest drawback(s) of this approach is that the file `src/Prelude.hs` which provides the `Prelude` module is absolutely required for the build process, that this fact is not very obvious, and that if you drop this file or have a very different folder structure the errors you will get are very much not helpful.

This template may not be something you *want* in the upstream repo in which case feel free to close this PR and/or give me a pointer to where this would be more suited. Otherwise this still needs to actually be integrated because I don't know how stack templates work and I didn't want to break anybodies builds by making a mistake there.