### PR TITLE
Add MonadLoggerIO instance for RIO

### DIFF
--- a/rio-orphans/ChangeLog.md
+++ b/rio-orphans/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio-orphans
 
+## 0.1.2.0
+
+* Add an instance for `MonadLoggerIO` typeclass, from the `monad-logger` library
+
 ## 0.1.1.0
 
 * Add an instance for `MonadLogger` typeclass, from the `monad-logger` library

--- a/rio-orphans/package.yaml
+++ b/rio-orphans/package.yaml
@@ -1,5 +1,5 @@
 name:        rio-orphans
-version:     0.1.1.0
+version:     0.1.2.0
 synopsis:    Orphan instances for the RIO type in the rio package
 description: See README and Haddocks at <https://www.stackage.org/package/rio-orphans>
 license:     MIT

--- a/rio-orphans/rio-orphans.cabal
+++ b/rio-orphans/rio-orphans.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: dd6b35b998c98b016949383b90c84c7de4983d5f2b68acaf535908f0c342ad6c
 
 name:           rio-orphans
-version:        0.1.1.0
+version:        0.1.2.0
 synopsis:       Orphan instances for the RIO type in the rio package
 description:    See README and Haddocks at <https://www.stackage.org/package/rio-orphans>
 category:       Control
@@ -42,6 +42,7 @@ library
     , resourcet
     , rio
     , transformers-base
+    , unliftio-core
   default-language: Haskell2010
 
 test-suite rio-orphans-test
@@ -64,4 +65,5 @@ test-suite rio-orphans-test
     , rio
     , rio-orphans
     , transformers-base
+    , unliftio-core
   default-language: Haskell2010


### PR DESCRIPTION
This is needed due to [persist-sqlite](https://github.com/yesodweb/persistent/blob/master/persistent-sqlite/Database/Persist/Sqlite.hs#L142) adding a `MonadLoggerIO` constraint to various functions.

I found this bug due to a call to `withSqliteConnInfo` in [pantry](https://github.com/commercialhaskell/pantry/blob/master/src/Pantry/SQLite.hs#L41).