### PR TITLE
Fix augment path wrt #234

### DIFF
--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -122,3 +122,6 @@ tests:
     - rio
     - hspec
     - QuickCheck
+    verbatim: |
+      build-tool-depends:
+          hspec-discover:hspec-discover

--- a/rio/rio.cabal
+++ b/rio/rio.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f3c92fe72c8e7fd35fdebcde2b50c754eec24d9c4d5bc1bded6f7876503fb693
+-- hash: e75ee136c29982f763267740af9411edc624282237b32358bc7877c683c52068
 
 name:           rio
 version:        0.1.20.0
@@ -172,3 +172,5 @@ test-suite spec
     build-depends:
         unix
   default-language: Haskell2010
+  build-tool-depends:
+      hspec-discover:hspec-discover

--- a/rio/test/RIO/Prelude/ExtraSpec.hs
+++ b/rio/test/RIO/Prelude/ExtraSpec.hs
@@ -1,7 +1,15 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module RIO.Prelude.ExtraSpec (spec) where
 
 import RIO
+import RIO.Process
 import Test.Hspec
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified System.FilePath as FP
 
 spec :: Spec
 spec = do
@@ -11,3 +19,25 @@ spec = do
           helper = pure . pure
       res <- foldMapM helper [1..10]
       res `shouldBe` [1..10]
+  describe "augmentPathMap" $ do
+    -- https://github.com/commercialhaskell/rio/issues/234
+    it "Doesn't duplicate PATH keys on windows" $ do
+      let pathKey :: T.Text
+#if WINDOWS
+          pathKey = "Path"
+#else
+          pathKey = "PATH"
+#endif
+          origEnv :: EnvVars
+          origEnv = Map.fromList [ ("foo", "3")
+                                 , ("bar", "baz")
+                                 , (pathKey, makePath ["/local/bin", "/usr/bin"])
+                                 ]
+      let res = second (fmap getPaths . Map.lookup "PATH") $ augmentPathMap ["/bin"] origEnv
+      res `shouldBe` Right (Just ["/bin", "/local/bin", "/usr/bin"])
+  where
+    makePath :: [T.Text] -> T.Text
+    makePath = T.intercalate (T.singleton FP.searchPathSeparator)
+
+    getPaths :: T.Text -> [T.Text]
+    getPaths = fmap T.pack . FP.splitSearchPath . T.unpack


### PR DESCRIPTION
On windows, env vars are generally case-insensitive.
Due to `type EnvVars = Map Text Text` augmentPathMap
assumes full uppercase "PATH" variable, which may lead
to surprising behavior if the current map
has a variable such as "Path".

This patch folds over the map and inserts any path
key as "PATH" on windows. That also means: if there
are multiple, the "last" one wins. There generally
isn't a sane solution if the input map already
has multiple path keys (how should they be merged,
which order?).

Fixes #234
