### PR TITLE
Fix augment path

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio
 
+## 0.1.21.0
+
+* Fix minor bug in `augmentPathMap` on windows wrt [#234](https://github.com/commercialhaskell/rio/issues/234) not adhering to case-insensitive semantics
+
 ## 0.1.20.0
 
 * Export `UnliftIO.QSem` and `UnliftIO.QSemN` in `RIO`

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -122,3 +122,6 @@ tests:
     - rio
     - hspec
     - QuickCheck
+    verbatim: |
+      build-tool-depends:
+          hspec-discover:hspec-discover

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -1,5 +1,5 @@
 name: rio
-version: 0.1.20.0
+version: 0.1.21.0
 synopsis: A standard library for Haskell
 description: See README and Haddocks at <https://www.stackage.org/package/rio>
 license: MIT

--- a/rio/test/RIO/Prelude/ExtraSpec.hs
+++ b/rio/test/RIO/Prelude/ExtraSpec.hs
@@ -1,7 +1,15 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module RIO.Prelude.ExtraSpec (spec) where
 
 import RIO
+import RIO.Process
 import Test.Hspec
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified System.FilePath as FP
 
 spec :: Spec
 spec = do
@@ -11,3 +19,25 @@ spec = do
           helper = pure . pure
       res <- foldMapM helper [1..10]
       res `shouldBe` [1..10]
+  describe "augmentPathMap" $ do
+    -- https://github.com/commercialhaskell/rio/issues/234
+    it "Doesn't duplicate PATH keys on windows" $ do
+      let pathKey :: T.Text
+#if WINDOWS
+          pathKey = "Path"
+#else
+          pathKey = "PATH"
+#endif
+          origEnv :: EnvVars
+          origEnv = Map.fromList [ ("foo", "3")
+                                 , ("bar", "baz")
+                                 , (pathKey, makePath ["/local/bin", "/usr/bin"])
+                                 ]
+      let res = second (fmap getPaths . Map.lookup "PATH") $ augmentPathMap ["/bin"] origEnv
+      res `shouldBe` Right (Just ["/bin", "/local/bin", "/usr/bin"])
+  where
+    makePath :: [T.Text] -> T.Text
+    makePath = T.intercalate (T.singleton FP.searchPathSeparator)
+
+    getPaths :: T.Text -> [T.Text]
+    getPaths = fmap T.pack . FP.splitSearchPath . T.unpack


### PR DESCRIPTION
On windows, env vars are generally case-insensitive.
Due to 'type EnvVars = Map Text Text' augmentPathMap
assumes full uppercase "PATH" variable, which may lead
to surprising behavior if the current map
has a variable such as "Path".

This patch folds over the map and inserts any path
key as "PATH" on windows. That also means: if there
are multiple, the "last" one wins. There generally
isn't a sane solution if the input map already
has multiple path keys (how should they be merged,
which order?).

Fixes #234
