### PR TITLE
Require microlens >= 0.4.2.0

### DIFF
--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -21,7 +21,7 @@ dependencies:
 - exceptions
 - filepath
 - hashable
-- microlens
+- microlens >= 0.4.2.0
 - microlens-mtl
 - mtl
 - primitive


### PR DESCRIPTION
`Lens.Micro.singular` is not available before `microlens-0.4.2.0`.