### PR TITLE
Support GHC 9.14.1-alpha1 and `containers-0.8`

### DIFF
--- a/rio/src/RIO/Map.hs
+++ b/rio/src/RIO/Map.hs
@@ -181,9 +181,17 @@ module RIO.Map
   , Data.Map.Strict.maxViewWithKey
 
   -- * Debugging
+#if MIN_VERSION_containers(0,5,9)
+  , Data.Map.Internal.Debug.showTree
+  , Data.Map.Internal.Debug.showTreeWith
+#else
   , Data.Map.Strict.showTree
   , Data.Map.Strict.showTreeWith
+#endif
   , Data.Map.Strict.valid
   ) where
 
+#if MIN_VERSION_containers(0,5,9)
+import qualified Data.Map.Internal.Debug
+#endif
 import qualified Data.Map.Strict

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-snapshot: lts-24.10
+snapshot: lts-24.10 # GHC 9.10.2
 packages:
 - rio
 - rio-orphans


### PR DESCRIPTION
`containers-0.8` is a boot package of GHC 9.14.1-alpha1, and removes `Data.Map.Strict.showTree` and `Data.Map.Strict.showTreeWith` first deprecated in `containers-0.5.9.1`.

Also bumps `stack.yaml` to Stackage LTS Haskell 24.6.