### PR TITLE
Fix #262 Pare back CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,23 +14,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         stack-yaml:
         - stack-ghc-9.12.2.yaml # GHC 9.12.2
         - stack-ghc-9.10.3.yaml # GHC 9.10.3
-        - stack-ghc-9.8.4.yaml # GHC 9.8.4
-        - stack-ghc-9.6.7.yaml # GHC 9.6.7
-        - stack-ghc-8.6.5.yaml # GHC 8.6.5 and base-4.12.0.0
-        exclude:
-        # macos-latest is macOS/AArch64 and GHC 8.6.5 did not support it
-        - os: macos-latest
-          stack-yaml: stack-ghc-8.6.5.yaml
         include:
-        # macos-latest is macOS/AArch64 and GHC 8.10.5 was first to support it.
-        # However, the GitHub runner can't find the LLVM version with
-        # GHC 8.10.7 or 9.0.2.
-        - os: macos-latest
-          stack-yaml: stack-ghc-9.2.8.yaml # GHC 9.2.8
+        - os: windows-latest
+          stack-yaml: stack-ghc-9.8.4.yaml # GHC 9.8.4
+        - os: ubuntu-latest
+          stack-yaml: stack-ghc-9.8.4.yaml # GHC 9.8.4
+        - os: windows-latest
+          stack-yaml: stack-ghc-9.6.7.yaml # GHC 9.6.7
+        - os: ubuntu-latest
+          stack-yaml: stack-ghc-9.6.7.yaml # GHC 9.6.7
+        - os: ubuntu-latest
+          stack-yaml: stack-ghc-9.4.8.yaml # GHC 9.4.8
+        - os: ubuntu-latest
+          stack-yaml: stack-ghc-8.6.5.yaml # GHC 8.6.5 and base-4.12.0.0
 
     steps:
     - name: Clone project

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributors Guide
+
+Thank you for considering contributing to the maintenance or development of
+`rio`, or otherwise supporting users of `rio`! We hope that the following
+information will encourage and assist you.
+
+## Continuous integration (CI)
+
+We use [GitHub Actions](https://docs.github.com/en/actions) to do CI on `rio`.
+The configuration of the workflows is in the YAML files in `.github/workflows`.
+The current active workflows are:
+
+### Linting - `lint.yml`
+
+This workflow will run if:
+
+* there is a pull request
+* commits are pushed to these branches: `master`.
+
+The workflow has one job (`style`). It runs on `ubuntu` only and applies
+yamllint and Hlint.
+
+### Testing - `tests.yml`
+
+This workflow will run if:
+
+* there is a pull request
+* commits are pushed to these branches: `master`.
+* requested
+
+The workflow has one job (`build`).
+
+The `build` job runs on a matrix of operating systems and Stack
+project-level configuration files specifying different versions of GHC. It
+builds and tests `rio` and `rio-orphans` with the following flags:
+`--fast --no-terminal`.
+
+The versions of GHC in the matrix are:
+
+* those specified by the current Stackage Nightly snapshot and the most recent
+  Stackage LTS Haskell snapshot, on Windows, macOS and Linux;
+
+* the most recent minor version of all major versions of GHC that have a
+  Stackage LTS Haskell snapshot first published within two years of the current
+  date, on Windows and Linux (for Unix-like operating systems);
+
+* the most recent minor version of the most recent major version of GHC not
+  included above, on Linux only; and
+
+* GHC 8.6.5 (`base-4.12.0.0`), on Linux only.
+
+In that regard:
+
+GHC |LTS|LTS first published
+----|---|-------------------
+9.10|24 |2025-07-13
+9.8 |23 |2024-12-09
+9.6 |22 |2023-12-16
+9.4 |21 |2023-06-20
+
+Its approach to creating a cache depends on the operating system. Its 'Cache
+dependencies on Unix-like OS' step caches the Stack root on Unix-like operating
+systems. Its 'Cache dependencies on Windows' step caches the same information
+on Windows, but takes into account that a relevant directory is located outside
+of the Stack root.

--- a/stack-ghc-9.12.2.yaml
+++ b/stack-ghc-9.12.2.yaml
@@ -1,4 +1,4 @@
-snapshot: nightly-2025-09-14 # GHC 9.12.2
+snapshot: nightly-2025-09-19 # GHC 9.12.2
 packages:
 - rio
 - rio-orphans

--- a/stack-ghc-9.4.8.yaml
+++ b/stack-ghc-9.4.8.yaml
@@ -1,0 +1,4 @@
+snapshot: lts-21.25 # GHC 9.4.8
+packages:
+- rio
+- rio-orphans


### PR DESCRIPTION
See:
* #262 

Also documents CI in new `CONTRIBUTING.md`.