### PR TITLE
Fix Utf8Builder instance of Monoid

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for rio
 
+## 0.1.24.0
+
+* Fix a bug in the `Utf8Builder` instance of `Monoid`, introduced in `rio-0.1.23.0`
+
 ## 0.1.23.0
 
 * Support GHC 9.14

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -1,5 +1,5 @@
 name: rio
-version: 0.1.23.0
+version: 0.1.24.0
 synopsis: A standard library for Haskell
 description: See README and Haddocks at <https://www.stackage.org/package/rio>
 license: MIT

--- a/rio/src/RIO/Prelude/Display.hs
+++ b/rio/src/RIO/Prelude/Display.hs
@@ -1,4 +1,8 @@
+{-# HLINT ignore "Use fold" #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module RIO.Prelude.Display
   ( Utf8Builder (..)
   , Display (..)
@@ -14,7 +18,6 @@ import           Data.ByteString          (ByteString)
 import qualified Data.ByteString.Lazy     as BL
 import qualified Data.ByteString.Builder  as BB
 import           Data.ByteString.Builder  (Builder)
-import           Data.Foldable            (fold)
 import           Data.Semigroup           (Semigroup(..))
 import           Data.Text                (Text)
 import qualified Data.Text.Lazy           as TL
@@ -38,9 +41,12 @@ newtype Utf8Builder = Utf8Builder { getUtf8Builder :: Builder }
 instance Monoid Utf8Builder where
   mempty = Utf8Builder mempty
   {-# INLINE mempty #-}
+
   mappend = (Data.Semigroup.<>)
   {-# INLINE mappend #-}
-  mconcat = fold
+
+  -- Data.Foldable.fold cannot be used here because it results in a circularity:
+  mconcat = foldr mappend mempty
   {-# INLINE mconcat #-}
 
 -- | @since 0.1.0.0

--- a/stack-ghc-9.10.3.yaml
+++ b/stack-ghc-9.10.3.yaml
@@ -1,4 +1,4 @@
-snapshot: lts-24.13 # GHC 9.10.3
+snapshot: lts-24.18 # GHC 9.10.3
 packages:
 - rio
 - rio-orphans

--- a/stack-ghc-9.12.2.yaml
+++ b/stack-ghc-9.12.2.yaml
@@ -1,4 +1,4 @@
-snapshot: nightly-2025-09-19 # GHC 9.12.2
+snapshot: nightly-2025-11-07 # GHC 9.12.2
 packages:
 - rio
 - rio-orphans

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-snapshot: lts-24.13 # GHC 9.10.3
+snapshot: lts-24.18 # GHC 9.10.3
 packages:
 - rio
 - rio-orphans

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 057c5a66404132b661211de21bb4490f6df89c162752a17f0df5a0959381b869
-    size: 726309
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/24/10.yaml
-  original: lts-24.10
+    sha256: 4cb7085bcc4e7d0b58a523df16a25201800a076f643445ec4f8bb78a94be652f
+    size: 726109
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/24/18.yaml
+  original: lts-24.18


### PR DESCRIPTION
See:
* #264 
* https://github.com/commercialhaskell/stack/issues/6819
* https://discourse.haskell.org/t/solved-help-rio-0-1-22-0-to-0-1-23-0-problem/13240/9

Tested by building and running a `stack` executable with a dependency on the package locally.