### PR TITLE
remove CPP conditional supporting base < 4.12

### DIFF
--- a/rio/src/RIO/Prelude/Extra.hs
+++ b/rio/src/RIO/Prelude/Extra.hs
@@ -86,13 +86,6 @@ whenM boolM action = boolM >>= (`when` action)
 unlessM :: Monad m => m Bool -> m () -> m ()
 unlessM boolM action = boolM >>= (`unless` action)
 
-#if !MIN_VERSION_base(4, 11, 0)
-(<&>) :: Functor f => f a -> (a -> b) -> f b
-as <&> f = f <$> as
-
-infixl 1 <&>
-#endif
-
 
 -- | Helper function to force an action to run in 'IO'. Especially
 -- useful for overly general contexts, like hspec tests.


### PR DESCRIPTION
addresses #278 

(I swear *just* I saw more of these, and going back to 4.8. must have been while I was checking old versions to see when we bumped which bounds, to make sure none of the warning fixes needed CPP... well anyway, there was still _one!_)